### PR TITLE
[FEAT] 58 예약 조회 API

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingController.java
@@ -4,6 +4,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,5 +49,18 @@ public class BookingController {
         Member member = memberService.getMember(userDetails.getUsername());
         BookingResponseDTO response = bookingService.createBooking(member, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "예약 상세 조회", description = "예약 ID로 예약 상세 정보를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "예약을 찾을 수 없음")
+    })
+    @GetMapping("/{bookingId}")
+    public ResponseEntity<BookingResponseDTO> getBookingById(
+            @PathVariable Long bookingId
+    ) {
+        BookingResponseDTO response = bookingService.getBookingById(bookingId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingRepository.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingRepository.java
@@ -2,8 +2,11 @@ package com.coDevs.cohiChat.booking;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.coDevs.cohiChat.booking.entity.AttendanceStatus;
 import com.coDevs.cohiChat.booking.entity.Booking;
@@ -21,4 +24,15 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
         LocalDate bookingDate,
         List<AttendanceStatus> excludedStatuses
     );
+
+    /**
+     * 게스트 ID로 예약 목록 조회 (예약 날짜 내림차순)
+     */
+    List<Booking> findByGuestIdOrderByBookingDateDesc(UUID guestId);
+
+    /**
+     * 호스트 ID로 예약 목록 조회 (TimeSlot의 userId가 호스트 ID인 예약, 예약 날짜 내림차순)
+     */
+    @Query("SELECT b FROM Booking b JOIN TimeSlot t ON b.timeSlotId = t.id WHERE t.userId = :hostId ORDER BY b.bookingDate DESC")
+    List<Booking> findByHostIdOrderByBookingDateDesc(@Param("hostId") UUID hostId);
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/GuestBookingController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/GuestBookingController.java
@@ -1,0 +1,39 @@
+package com.coDevs.cohiChat.booking;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coDevs.cohiChat.booking.response.BookingResponseDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Guest Booking", description = "게스트 예약 조회 API")
+@RestController
+@RequestMapping("/api/guests")
+@RequiredArgsConstructor
+public class GuestBookingController {
+
+    private final BookingService bookingService;
+
+    @Operation(summary = "게스트 예약 목록 조회", description = "게스트 ID로 해당 게스트의 예약 목록을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/{guestId}/bookings")
+    public ResponseEntity<List<BookingResponseDTO>> getBookingsByGuestId(
+            @PathVariable UUID guestId
+    ) {
+        List<BookingResponseDTO> response = bookingService.getBookingsByGuestId(guestId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/HostBookingController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/HostBookingController.java
@@ -1,0 +1,39 @@
+package com.coDevs.cohiChat.booking;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coDevs.cohiChat.booking.response.BookingResponseDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Host Booking", description = "호스트 예약 조회 API")
+@RestController
+@RequestMapping("/api/hosts")
+@RequiredArgsConstructor
+public class HostBookingController {
+
+    private final BookingService bookingService;
+
+    @Operation(summary = "호스트 예약 목록 조회", description = "호스트 ID로 해당 호스트의 예약 목록을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/{hostId}/bookings")
+    public ResponseEntity<List<BookingResponseDTO>> getBookingsByHostId(
+            @PathVariable UUID hostId
+    ) {
+        List<BookingResponseDTO> response = bookingService.getBookingsByHostId(hostId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
 	HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "호스트가 없습니다."),
 	CALENDAR_NOT_FOUND(HttpStatus.NOT_FOUND, "캘린더가 없습니다."),
 	TIMESLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "시간대가 없습니다."),
+	BOOKING_NOT_FOUND(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다."),
 
 	CALENDAR_ALREADY_EXISTS(HttpStatus.CONFLICT, "캘린더가 이미 존재합니다."),
 	TIMESLOT_OVERLAP(HttpStatus.CONFLICT, "겹치는 시간대가 이미 존재합니다."),

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/BookingControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/BookingControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -200,4 +201,46 @@ class BookingControllerTest {
                 .content(requestBody))
             .andExpect(status().isNotFound());
     }
+
+    @Test
+    @DisplayName("성공: 예약 상세 조회 - 200 OK")
+    void getBookingByIdSuccess() throws Exception {
+        // given
+        Long bookingId = 1L;
+        BookingResponseDTO response = BookingResponseDTO.builder()
+            .id(bookingId)
+            .timeSlotId(TIME_SLOT_ID)
+            .guestId(GUEST_ID)
+            .bookingDate(FUTURE_DATE)
+            .startTime(LocalTime.of(10, 0))
+            .endTime(LocalTime.of(11, 0))
+            .topic("프로젝트 상담")
+            .description("Spring Boot 프로젝트 관련 질문")
+            .attendanceStatus(AttendanceStatus.SCHEDULED)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        given(bookingService.getBookingById(bookingId)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/bookings/{bookingId}", bookingId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(bookingId))
+            .andExpect(jsonPath("$.timeSlotId").value(TIME_SLOT_ID))
+            .andExpect(jsonPath("$.topic").value("프로젝트 상담"));
+    }
+
+    @Test
+    @DisplayName("실패: 예약 상세 조회 - 존재하지 않는 예약 - 404")
+    void getBookingByIdFailNotFound() throws Exception {
+        // given
+        Long bookingId = 999L;
+        given(bookingService.getBookingById(bookingId))
+            .willThrow(new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/bookings/{bookingId}", bookingId))
+            .andExpect(status().isNotFound());
+    }
+
 }

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/GuestBookingControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/GuestBookingControllerTest.java
@@ -1,0 +1,98 @@
+package com.coDevs.cohiChat.booking;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.coDevs.cohiChat.booking.entity.AttendanceStatus;
+import com.coDevs.cohiChat.booking.response.BookingResponseDTO;
+import com.coDevs.cohiChat.global.security.jwt.JwtTokenProvider;
+
+@WebMvcTest(GuestBookingController.class)
+@AutoConfigureMockMvc
+@WithMockUser(username = "guest")
+class GuestBookingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BookingService bookingService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private static final UUID GUEST_ID = UUID.randomUUID();
+    private static final Long TIME_SLOT_ID = 1L;
+    private static final LocalDate FUTURE_DATE = LocalDate.now().plusDays(7);
+
+    @Test
+    @DisplayName("성공: 게스트 예약 목록 조회 - 200 OK")
+    void getBookingsByGuestIdSuccess() throws Exception {
+        // given
+        BookingResponseDTO response1 = BookingResponseDTO.builder()
+            .id(1L)
+            .timeSlotId(TIME_SLOT_ID)
+            .guestId(GUEST_ID)
+            .bookingDate(FUTURE_DATE)
+            .startTime(LocalTime.of(10, 0))
+            .endTime(LocalTime.of(11, 0))
+            .topic("첫번째 상담")
+            .description("설명1")
+            .attendanceStatus(AttendanceStatus.SCHEDULED)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        BookingResponseDTO response2 = BookingResponseDTO.builder()
+            .id(2L)
+            .timeSlotId(TIME_SLOT_ID)
+            .guestId(GUEST_ID)
+            .bookingDate(FUTURE_DATE.plusDays(1))
+            .startTime(LocalTime.of(14, 0))
+            .endTime(LocalTime.of(15, 0))
+            .topic("두번째 상담")
+            .description("설명2")
+            .attendanceStatus(AttendanceStatus.SCHEDULED)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        given(bookingService.getBookingsByGuestId(GUEST_ID))
+            .willReturn(List.of(response2, response1));
+
+        // when & then
+        mockMvc.perform(get("/api/guests/{guestId}/bookings", GUEST_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].id").value(2))
+            .andExpect(jsonPath("$[1].id").value(1));
+    }
+
+    @Test
+    @DisplayName("성공: 게스트 예약 목록이 없으면 빈 리스트 반환 - 200 OK")
+    void getBookingsByGuestIdReturnsEmptyList() throws Exception {
+        // given
+        given(bookingService.getBookingsByGuestId(GUEST_ID))
+            .willReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/guests/{guestId}/bookings", GUEST_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(0));
+    }
+}

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/HostBookingControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/HostBookingControllerTest.java
@@ -1,0 +1,99 @@
+package com.coDevs.cohiChat.booking;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.coDevs.cohiChat.booking.entity.AttendanceStatus;
+import com.coDevs.cohiChat.booking.response.BookingResponseDTO;
+import com.coDevs.cohiChat.global.security.jwt.JwtTokenProvider;
+
+@WebMvcTest(HostBookingController.class)
+@AutoConfigureMockMvc
+@WithMockUser(username = "host")
+class HostBookingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BookingService bookingService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private static final UUID HOST_ID = UUID.randomUUID();
+    private static final UUID GUEST_ID = UUID.randomUUID();
+    private static final Long TIME_SLOT_ID = 1L;
+    private static final LocalDate FUTURE_DATE = LocalDate.now().plusDays(7);
+
+    @Test
+    @DisplayName("성공: 호스트 예약 목록 조회 - 200 OK")
+    void getBookingsByHostIdSuccess() throws Exception {
+        // given
+        BookingResponseDTO response1 = BookingResponseDTO.builder()
+            .id(1L)
+            .timeSlotId(TIME_SLOT_ID)
+            .guestId(GUEST_ID)
+            .bookingDate(FUTURE_DATE)
+            .startTime(LocalTime.of(10, 0))
+            .endTime(LocalTime.of(11, 0))
+            .topic("첫번째 상담")
+            .description("설명1")
+            .attendanceStatus(AttendanceStatus.SCHEDULED)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        BookingResponseDTO response2 = BookingResponseDTO.builder()
+            .id(2L)
+            .timeSlotId(TIME_SLOT_ID)
+            .guestId(GUEST_ID)
+            .bookingDate(FUTURE_DATE.plusDays(1))
+            .startTime(LocalTime.of(14, 0))
+            .endTime(LocalTime.of(15, 0))
+            .topic("두번째 상담")
+            .description("설명2")
+            .attendanceStatus(AttendanceStatus.SCHEDULED)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        given(bookingService.getBookingsByHostId(HOST_ID))
+            .willReturn(List.of(response2, response1));
+
+        // when & then
+        mockMvc.perform(get("/api/hosts/{hostId}/bookings", HOST_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].id").value(2))
+            .andExpect(jsonPath("$[1].id").value(1));
+    }
+
+    @Test
+    @DisplayName("성공: 호스트 예약 목록이 없으면 빈 리스트 반환 - 200 OK")
+    void getBookingsByHostIdReturnsEmptyList() throws Exception {
+        // given
+        given(bookingService.getBookingsByHostId(HOST_ID))
+            .willReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/hosts/{hostId}/bookings", HOST_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(0));
+    }
+}


### PR DESCRIPTION
## Summary
- 예약 상세 조회 API (GET /api/bookings/{bookingId})
- 게스트 예약 목록 조회 API (GET /api/guests/{guestId}/bookings)
- 호스트 예약 목록 조회 API (GET /api/hosts/{hostId}/bookings)

## Changes
- `BookingController`: 예약 상세 조회 엔드포인트 추가
- `GuestBookingController`: 게스트 예약 목록 조회 컨트롤러 신규
- `HostBookingController`: 호스트 예약 목록 조회 컨트롤러 신규
- `BookingService`: 조회 서비스 로직 추가
- `BookingRepository`: 게스트/호스트별 조회 메서드 추가
- `ErrorCode`: BOOKING_NOT_FOUND 추가

## Test plan
- [x] BookingServiceTest 통과
- [x] BookingControllerTest 통과
- [x] GuestBookingControllerTest 통과
- [x] HostBookingControllerTest 통과
- [x] 전체 빌드 성공

Closes #58