### PR TITLE
feat : 59 호스트 예약 수정

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.coDevs.cohiChat.booking.request.BookingCreateRequestDTO;
+import com.coDevs.cohiChat.booking.request.BookingScheduleUpdateRequestDTO;
 import com.coDevs.cohiChat.booking.response.BookingResponseDTO;
 import com.coDevs.cohiChat.member.MemberService;
 import com.coDevs.cohiChat.member.entity.Member;
@@ -61,6 +63,27 @@ public class BookingController {
             @PathVariable Long bookingId
     ) {
         BookingResponseDTO response = bookingService.getBookingById(bookingId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "예약 일정 수정", description = "호스트가 예약의 일정(날짜, 타임슬롯)을 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "수정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)"),
+        @ApiResponse(responseCode = "401", description = "인증 필요"),
+        @ApiResponse(responseCode = "403", description = "권한 없음 (호스트만 수정 가능)"),
+        @ApiResponse(responseCode = "404", description = "예약 또는 타임슬롯을 찾을 수 없음"),
+        @ApiResponse(responseCode = "409", description = "이미 예약된 시간대"),
+        @ApiResponse(responseCode = "422", description = "비즈니스 규칙 위반 (과거 날짜, 요일 불가)")
+    })
+    @PatchMapping("/{bookingId}/schedule")
+    public ResponseEntity<BookingResponseDTO> updateBookingSchedule(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long bookingId,
+            @Valid @RequestBody BookingScheduleUpdateRequestDTO request
+    ) {
+        Member member = memberService.getMember(userDetails.getUsername());
+        BookingResponseDTO response = bookingService.updateBookingSchedule(member, bookingId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingRepository.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingRepository.java
@@ -35,4 +35,18 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
      */
     @Query("SELECT b FROM Booking b JOIN TimeSlot t ON b.timeSlotId = t.id WHERE t.userId = :hostId ORDER BY b.bookingDate DESC")
     List<Booking> findByHostIdOrderByBookingDateDesc(@Param("hostId") UUID hostId);
+
+    /**
+     * 특정 타임슬롯과 날짜에 취소되지 않은 예약이 존재하는지 확인 (자신의 예약은 제외)
+     * @param timeSlotId 타임슬롯 ID
+     * @param bookingDate 예약 날짜
+     * @param excludedStatuses 제외할 상태 목록 (CANCELLED, SAME_DAY_CANCEL 등)
+     * @param excludeBookingId 제외할 예약 ID (자기 자신)
+     */
+    boolean existsByTimeSlotIdAndBookingDateAndAttendanceStatusNotInAndIdNot(
+        Long timeSlotId,
+        LocalDate bookingDate,
+        List<AttendanceStatus> excludedStatuses,
+        Long excludeBookingId
+    );
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/entity/Booking.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/entity/Booking.java
@@ -92,4 +92,12 @@ public class Booking {
         booking.attendanceStatus = AttendanceStatus.SCHEDULED;
         return booking;
     }
+
+    public void updateSchedule(Long timeSlotId, LocalDate bookingDate) {
+        Objects.requireNonNull(timeSlotId, "timeSlotId must not be null");
+        Objects.requireNonNull(bookingDate, "bookingDate must not be null");
+
+        this.timeSlotId = timeSlotId;
+        this.bookingDate = bookingDate;
+    }
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/request/BookingScheduleUpdateRequestDTO.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/request/BookingScheduleUpdateRequestDTO.java
@@ -1,0 +1,24 @@
+package com.coDevs.cohiChat.booking.request;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookingScheduleUpdateRequestDTO {
+
+    @NotNull(message = "타임슬롯 ID는 필수 입력 항목입니다.")
+    private Long timeSlotId;
+
+    @NotNull(message = "예약 날짜는 필수 입력 항목입니다.")
+    @FutureOrPresent(message = "예약 날짜는 오늘 이후여야 합니다.")
+    private LocalDate bookingDate;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #59

---

## 📦 뭘 만들었나요? (What)

호스트가 예약의 일정(날짜, 타임슬롯)을 수정할 수 있는 API 구현

**엔드포인트**: `PATCH /api/bookings/{bookingId}/schedule`

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. **호스트 권한 검증**: 기존 TimeSlot의 userId를 통해 호스트 권한을 검증하는 방식 유지
2. **중복 예약 검증**: 자기 자신의 예약은 제외하고 중복 검사하도록 별도 Repository 메서드 추가
3. **기존 검증 로직 재사용**: 과거 날짜, 요일 검증 등 기존 로직을 재사용하여 일관성 유지

---

## 어떻게 테스트했나요? (Test)

단위 테스트 작성 (Mockito)

<details>
<summary>테스트 시나리오</summary>

**Service 테스트 (6개)**
1. 호스트 예약 일정 수정 성공
2. 호스트가 아닌 사용자 수정 시도 실패 (ACCESS_DENIED)
3. 존재하지 않는 예약 수정 시도 실패 (BOOKING_NOT_FOUND)
4. 과거 날짜로 수정 시도 실패 (PAST_BOOKING)
5. 허용되지 않는 요일로 수정 시도 실패 (WEEKDAY_NOT_AVAILABLE)
6. 중복 예약 발생 시 실패 (BOOKING_ALREADY_EXISTS)

**Controller 테스트 (4개)**
1. 예약 일정 수정 성공 (200 OK)
2. 권한 없는 사용자 요청 시 403
3. 존재하지 않는 예약 요청 시 404
4. 과거 날짜 요청 시 400 (DTO 검증)

</details>

---

## 참고사항 / 회고 메모 (Notes)

- Swagger 문서화 완료 (`/swagger-ui.html`에서 확인 가능)
- TDD 방식으로 개발 진행