### PR TITLE
feat : 83 FE 타임슬롯 조회 API 마이그레이션 (useTimeslots.ts)

### DIFF
--- a/frontend/src/hooks/useHost.ts
+++ b/frontend/src/hooks/useHost.ts
@@ -18,3 +18,9 @@ export function useHosts() {
     });
 }
 
+export function useHost(username: string) {
+    const { data: hosts, ...rest } = useHosts();
+    const host = hosts?.find((h) => h.username === username) ?? null;
+    return { data: host, ...rest };
+}
+

--- a/frontend/src/hooks/useTimeslots.ts
+++ b/frontend/src/hooks/useTimeslots.ts
@@ -1,23 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { httpClient } from '~/libs/httpClient';
 import { ITimeSlot } from '~/types/timeslot';
+import { useHost } from './useHost';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080/api';
 
-export function useTimeslots(hostname: string, date: Date | null) {
+export function useTimeslots(hostname: string) {
+    const { data: host } = useHost(hostname);
+
     return useQuery<ITimeSlot[]>({
-        queryKey: ['timeslots', hostname, date?.toISOString()],
+        queryKey: ['timeslots', hostname, host?.id],
         queryFn: async () => {
-            if (!date) throw new Error("Date is required");
+            if (!host?.id) throw new Error("Host not found");
 
-            const year = date.getFullYear();
-            const month = date.getMonth() + 1;
-
-            const url = `${API_URL}/time-slots/${hostname}?year=${year}&month=${month}`;
+            const url = `${API_URL}/timeslot/v1/hosts/${host.id}`;
             const data: ITimeSlot[] = await httpClient(url);
             return data;
-           
         },
-        enabled: !!date,
+        enabled: !!host?.id,
     });
 } 

--- a/frontend/src/pages/calendar/Calendar.tsx
+++ b/frontend/src/pages/calendar/Calendar.tsx
@@ -27,7 +27,7 @@ function Calendar({ baseDate }: { baseDate?: Date }) {
     const navigate = useNavigate();
     const auth = useAuth();
     const calendar = useCalendarEvent(slug);
-    const { data: timeslots = [] } = useTimeslots(slug, selectedDate);
+    const { data: timeslots = [] } = useTimeslots(slug);
     const { data: bookingsApi = [], refetch: refetchBookings } = useBookings(slug, selectedDate);
     const bookingsStream = useBookingsStreamQuery({
         endpoint: `${API_URL}/calendar/${slug}/bookings/stream?year=${year}&month=${month}`,

--- a/frontend/src/types/timeslot.d.ts
+++ b/frontend/src/types/timeslot.d.ts
@@ -1,8 +1,11 @@
-import { StringTime } from "./base";
+import { ISO8601String, StringTime } from "./base";
 
 export interface ITimeSlot {
     id: number;
+    userId: string;
     startTime: StringTime;
     endTime: StringTime;
     weekdays: number[];
+    createdAt: ISO8601String;
+    updatedAt: ISO8601String;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #83

---

## 📦 뭘 만들었나요? (What)

타임슬롯 조회 API를 Python 백엔드에서 Spring Boot로 마이그레이션

**변경 사항:**
- 엔드포인트 변경: `/time-slots/{hostname}` → `/timeslot/v1/hosts/{hostId}`
- `useHost()` 훅 추가: username → hostId 변환
- `ITimeSlot` 타입 업데이트: `userId`, `createdAt`, `updatedAt` 필드 추가
- `useTimeslots()` 호출부 수정: date 파라미터 제거

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- 새 API는 hostId(UUID)를 요구하지만, 캘린더 페이지에서는 username만 사용 가능
- 백엔드에 username으로 hostId를 조회하는 공개 API가 없어서 임시로 `useHosts()`에서 전체 목록을 가져와 필터링하는 방식 선택

---

## 어떻게 테스트했나요? (Test)

- `pnpm build` 성공 확인
- `pnpm lint` 통과 확인

---

## 참고사항 / 회고 메모 (Notes)

### 후속 개선 필요 사항 (P2)

#### 1. 호스트 미발견 시 사용자 피드백 부재
**파일**: `hooks/useTimeslots.ts:13-14`
- 존재하지 않는 username 입력 시 에러 발생하지만 UI 피드백 없음
- **조치**: `isError` 상태 활용하여 "호스트를 찾을 수 없습니다" 메시지 표시 권장

#### 2. 비효율적인 호스트 조회 방식
**파일**: `hooks/useHost.ts:20-24`
- 전체 호스트 목록 가져온 후 클라이언트에서 필터링 → 호스트 증가 시 비효율
- **조치**: 장기적으로 백엔드에 `GET /members/v1/public/{username}` API 추가 권장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeslot information now includes user ID and timestamp metadata for creation and updates.

* **Refactor**
  * Enhanced timeslot retrieval system with improved host-based data management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->