### PR TITLE
feat : 60 게스트 예약 수정 API

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
@@ -12,6 +12,7 @@ import com.coDevs.cohiChat.booking.entity.AttendanceStatus;
 import com.coDevs.cohiChat.booking.entity.Booking;
 import com.coDevs.cohiChat.booking.request.BookingCreateRequestDTO;
 import com.coDevs.cohiChat.booking.request.BookingScheduleUpdateRequestDTO;
+import com.coDevs.cohiChat.booking.request.BookingUpdateRequestDTO;
 import com.coDevs.cohiChat.booking.response.BookingResponseDTO;
 import com.coDevs.cohiChat.global.exception.CustomException;
 import com.coDevs.cohiChat.global.exception.ErrorCode;
@@ -162,6 +163,36 @@ public class BookingService {
 
     private void validateHostAccess(Booking booking, UUID requesterId) {
         if (!booking.getTimeSlot().getUserId().equals(requesterId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    @Transactional
+    public BookingResponseDTO updateBooking(Long bookingId, UUID guestId, BookingUpdateRequestDTO request) {
+        Booking booking = bookingRepository.findById(bookingId)
+            .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+
+        validateGuestAccess(booking, guestId);
+        validateNotPastBooking(request.getBookingDate());
+
+        TimeSlot newTimeSlot = timeSlotRepository.findById(request.getTimeSlotId())
+            .orElseThrow(() -> new CustomException(ErrorCode.TIMESLOT_NOT_FOUND));
+
+        UUID originalHostId = booking.getTimeSlot().getUserId();
+        if (!newTimeSlot.getUserId().equals(originalHostId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        validateWeekdayAvailable(newTimeSlot, request.getBookingDate());
+        validateNotDuplicateBooking(newTimeSlot, request.getBookingDate(), bookingId);
+
+        booking.update(request.getTopic(), request.getDescription(), newTimeSlot, request.getBookingDate());
+
+        return BookingResponseDTO.from(booking);
+    }
+
+    private void validateGuestAccess(Booking booking, UUID requesterId) {
+        if (!booking.getGuestId().equals(requesterId)) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
     }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/controller/BookingController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/controller/BookingController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.coDevs.cohiChat.booking.request.BookingCreateRequestDTO;
 import com.coDevs.cohiChat.booking.request.BookingScheduleUpdateRequestDTO;
+import com.coDevs.cohiChat.booking.request.BookingUpdateRequestDTO;
 import com.coDevs.cohiChat.booking.response.BookingResponseDTO;
 import com.coDevs.cohiChat.member.MemberService;
 import com.coDevs.cohiChat.member.entity.Member;
@@ -119,6 +120,27 @@ public class BookingController {
     ) {
         Member member = memberService.getMember(userDetails.getUsername());
         BookingResponseDTO response = bookingService.updateBookingSchedule(bookingId, member.getId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "예약 수정 (게스트)", description = "게스트가 본인의 예약 정보(주제, 설명, 일정)를 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "예약 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)"),
+        @ApiResponse(responseCode = "401", description = "인증 필요"),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음 (게스트만 수정 가능)"),
+        @ApiResponse(responseCode = "404", description = "예약 또는 타임슬롯을 찾을 수 없음"),
+        @ApiResponse(responseCode = "409", description = "중복 예약"),
+        @ApiResponse(responseCode = "422", description = "비즈니스 규칙 위반 (과거 날짜, 요일 불가)")
+    })
+    @PatchMapping("/{bookingId}")
+    public ResponseEntity<BookingResponseDTO> updateBooking(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long bookingId,
+            @Valid @RequestBody BookingUpdateRequestDTO request
+    ) {
+        Member member = memberService.getMember(userDetails.getUsername());
+        BookingResponseDTO response = bookingService.updateBooking(bookingId, member.getId(), request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/entity/Booking.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/entity/Booking.java
@@ -106,4 +106,16 @@ public class Booking {
         this.timeSlot = newTimeSlot;
         this.bookingDate = newBookingDate;
     }
+
+    public void update(String topic, String description, TimeSlot timeSlot, LocalDate bookingDate) {
+        Objects.requireNonNull(topic, "topic must not be null");
+        Objects.requireNonNull(description, "description must not be null");
+        Objects.requireNonNull(timeSlot, "timeSlot must not be null");
+        Objects.requireNonNull(bookingDate, "bookingDate must not be null");
+
+        this.topic = topic;
+        this.description = description;
+        this.timeSlot = timeSlot;
+        this.bookingDate = bookingDate;
+    }
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/request/BookingUpdateRequestDTO.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/request/BookingUpdateRequestDTO.java
@@ -1,0 +1,37 @@
+package com.coDevs.cohiChat.booking.request;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookingUpdateRequestDTO {
+
+    @NotNull(message = "타임슬롯 ID는 필수 입력 항목입니다.")
+    private Long timeSlotId;
+
+    @JsonProperty("when")
+    @NotNull(message = "예약 날짜는 필수 입력 항목입니다.")
+    @FutureOrPresent(message = "예약 날짜는 오늘 이후여야 합니다.")
+    private LocalDate bookingDate;
+
+    @NotBlank(message = "상담 주제는 필수 입력 항목입니다.")
+    @Size(max = 255, message = "상담 주제는 255자 이내로 입력해주세요.")
+    private String topic;
+
+    @NotBlank(message = "상담 설명은 필수 입력 항목입니다.")
+    @Size(max = 2000, message = "상담 설명은 2000자 이내로 입력해주세요.")
+    private String description;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #60

---

## 📦 뭘 만들었나요? (What)

게스트가 본인 예약의 주제(topic), 설명(description), 일정(when, timeSlotId)을 수정할 수 있는 API를 구현했습니다.

- `PATCH /api/bookings/{bookingId}` 엔드포인트 추가
- `BookingUpdateRequestDTO` 생성
- `Booking.update()` 메서드 추가
- `BookingService.updateBooking()` 메서드 추가
- 게스트 권한 검증 (`validateGuestAccess`)

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. **호스트용 API(`/schedule`)와 게스트용 API 분리**
   - 호스트는 `PATCH /{bookingId}/schedule`로 일정만 수정
   - 게스트는 `PATCH /{bookingId}`로 전체 정보(topic, description, when, timeSlotId) 수정
   - 역할별 권한을 명확히 분리하여 보안성 향상

2. **같은 호스트의 타임슬롯으로만 변경 가능**
   - 게스트가 다른 호스트의 타임슬롯으로 예약을 옮기는 것을 방지
   - 기존 예약의 호스트 관계 유지

---

## 어떻게 테스트했나요? (Test)

단위 테스트 작성 (BookingServiceTest)

<details>
<summary>테스트 시나리오</summary>

1. 성공: 게스트가 본인 예약을 수정할 수 있다
2. 실패: 호스트가 게스트용 수정 API로 수정 시도 → ACCESS_DENIED
3. 실패: 다른 게스트가 수정 시도 → ACCESS_DENIED
4. 실패: 존재하지 않는 예약 수정 시도 → BOOKING_NOT_FOUND
5. 실패: 과거 날짜로 예약 수정 시도 → PAST_BOOKING
6. 실패: 다른 호스트의 타임슬롯으로 예약 수정 시도 → ACCESS_DENIED

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 기존 호스트용 일정 수정 API(#59)와 권한 검증 로직이 다름
  - 호스트용: `validateHostAccess()` - 호스트만 수정 가능
  - 게스트용: `validateGuestAccess()` - 게스트만 수정 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guests can now update their bookings with new time slots, dates, topics, and descriptions, with validation to ensure booking dates are valid and the selected time slot is assigned to the original host.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->