### PR TITLE
feat : 82 FE 호스트 목록 조회 API 마이그레이션 (useHost.ts)

### DIFF
--- a/frontend/src/hooks/useHost.ts
+++ b/frontend/src/hooks/useHost.ts
@@ -8,7 +8,7 @@ export function useHosts() {
     return useQuery<MemberResponseDTO[]>({
         queryKey: ['hosts'],
         queryFn: async () => {
-            const response = await httpClient<MemberResponseDTO[]>(`${API_URL}/account/hosts`);
+            const response = await httpClient<MemberResponseDTO[]>(`${API_URL}/members/v1/hosts`);
             if (!response) {
                 throw new Error('Failed to fetch hosts');
             }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #82 

---

## 📦 뭘 만들었나요? (What)
- `useHost.ts` 호스트 목록 조회 API 엔드포인트 마이그레이션
- `/account/hosts` → `/members/v1/hosts`로 변경

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**
- Python FastAPI → Spring Boot 백엔드 전환에 따른 API 경로 변경
- 기존 응답 타입 `MemberResponseDTO[]` 유지 (BE API 호환)

---

## 어떻게 테스트했나요? (Test)
- ESLint 검사 통과
- 빌드 테스트 (기존 코드 이슈로 실패, 본 변경과 무관)

## 참고사항 / 회고 메모 (Notes)
- `useHost.ts`에 대한 테스트 파일 추후 추가 고려