### PR TITLE
feat: Docker Compose 프로덕션 설정 (#115)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,6 @@
 services:
   frontend:
+    container_name: cohi-chat-frontend
     build:
       context: ./frontend
       dockerfile: Dockerfile
@@ -9,6 +10,13 @@ services:
       backend:
         condition: service_healthy
     restart: unless-stopped
+    networks:
+      - cohi-chat-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost/health"]
       interval: 30s
@@ -17,6 +25,7 @@ services:
       start_period: 10s
 
   backend:
+    container_name: cohi-chat-backend
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -29,6 +38,13 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
     restart: unless-stopped
+    networks:
+      - cohi-chat-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/actuator/health"]
       interval: 30s
@@ -39,3 +55,7 @@ services:
 volumes:
   sqlite-data:
     driver: local
+
+networks:
+  cohi-chat-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- 프로덕션용 Docker Compose 설정
- 서비스 간 네트워크 설정 추가
- 컨테이너 이름 및 로깅 설정 추가
- 헬스체크 기반 서비스 의존성 관리

## Test plan
- [ ] docker-compose -f docker-compose.prod.yml up 실행 확인
- [ ] 서비스 간 통신 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 환경 배포를 위한 Docker Compose 구성 추가
  * 프론트엔드(포트 80) 및 백엔드(포트 8080) 서비스 자동 구성
  * 헬스 체크 및 자동 재시작 정책으로 안정성 강화
  * 데이터 지속성을 위한 볼륨 및 격리된 네트워크 설정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->