### PR TITLE
fix: #147 deploy-backend.yml EC2 배포 경로 수정

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -25,13 +25,13 @@ jobs:
             set -e
 
             # Clone or pull repository
-            if [ -d "/home/ec2-user/cohi-chat" ]; then
-              cd /home/ec2-user/cohi-chat
+            if [ -d ~/cohi-chat ]; then
+              cd ~/cohi-chat
               git fetch origin main
               git reset --hard origin/main
             else
-              git clone https://github.com/CheHyeonYeong/cohi-chat.git /home/ec2-user/cohi-chat
-              cd /home/ec2-user/cohi-chat
+              git clone https://github.com/CheHyeonYeong/cohi-chat.git ~/cohi-chat
+              cd ~/cohi-chat
             fi
 
             # Build and run backend
@@ -50,7 +50,7 @@ jobs:
             docker run -d \
               --name cohi-chat-backend \
               -p 8080:8080 \
-              -v /home/ec2-user/cohi-chat-data:/app/data \
+              -v ~/cohi-chat-data:/app/data \
               --restart unless-stopped \
               cohi-chat-backend:$IMAGE_TAG
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #147

---

## 📦 뭘 만들었나요? (What)

deploy-backend.yml의 하드코딩된 절대경로(`/home/ec2-user/`)를 `~`(홈 디렉토리)로 변경

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

EC2 인스턴스가 Ubuntu AMI라서 SSH 접속 사용자가 `ubuntu`인데, 스크립트에 `/home/ec2-user/cohi-chat`이 하드코딩되어 있어 Permission Denied 에러가 발생했습니다.

`/home/ec2-user/` 디렉토리는 EC2에 존재하지 않으며, `ubuntu` 사용자는 `/home/` 아래에 새 디렉토리를 생성할 권한이 없습니다.

`~`를 사용하면 SSH 접속 사용자가 누구든 자신의 홈 디렉토리를 사용하므로 권한 문제가 발생하지 않습니다. 다른 워크플로우(deploy.yml, server-deploy-prod.yml)도 동일하게 `~`를 사용하고 있습니다.

---

## 어떻게 테스트했나요? (Test)

EC2 Instance Connect로 접속하여 확인:
- `whoami` → `ubuntu`
- `ls -ld /home/ec2-user` → `No such file or directory`
- `/home/` 아래에 `ubuntu` 디렉토리만 존재 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. main에 머지 후 Deploy Backend 워크플로우 실행
2. EC2에 정상 배포 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

변경 내용:
- `deploy-backend.yml`의 `/home/ec2-user/cohi-chat` → `~/cohi-chat` (4곳)
- docker volume 경로 `/home/ec2-user/cohi-chat-data` → `~/cohi-chat-data` (1곳)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 구성이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->