### PR TITLE
fix: 애플리케이션 실행 시 JVM 인코딩을 UTF-8로 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -8,6 +8,11 @@ group = 'com.coDevs'
 version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
+bootRun {
+    // 애플리케이션 실행 시 JVM 인코딩을 UTF-8로 설정
+    jvmArgs "-Dfile.encoding=UTF-8", "-Dsun.stdout.encoding=UTF-8", "-Dsun.stderr.encoding=UTF-8"
+}
+
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)


### PR DESCRIPTION
## 🔗 관련 이슈
- N/A

---

## 📦 뭘 만들었나요? (What)

`build.gradle`에 JVM 인코딩 UTF-8 설정을 추가하여 로그 깨짐 현상을 완화했습니다.

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- Windows 환경에서 기본 인코딩이 UTF-8이 아니어서 한글 로그가 깨지는 현상 발생
- `build.gradle`에서 JVM 옵션으로 지정하여 환경에 관계없이 일관된 인코딩 보장

---

## 어떻게 테스트했나요? (Test)

- `./gradlew build` 성공
- 로그 출력 시 한글 깨짐 해소 확인

---

## 참고사항 / 회고 메모 (Notes)

- 1 file changed (`backend/build.gradle`)