### PR TITLE
chore: #167 푸딩캠프 관련 내용 제거

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,74 +1,41 @@
-# 테스트 코드를 작성하며 구현하는 푸딩캠프 캘린더
+# cohi-chat Frontend
 
-- https://github.com/realworldpudding/hands-on/tree/fe-testing-calendar
-- https://www.puddingcamp.com/topics/getting-started-with-react
+1:1 미팅 예약 서비스의 프론트엔드 애플리케이션입니다.
 
+## 기술 스택
 
-## 개발 모드
+- React 18, TypeScript
+- Vite
+- TanStack Router / Query
+- Tailwind CSS
+- pnpm
 
-- 구동 : `pnpm dev`
-- 빌드 : `pnpm build`
+## 개발 명령어
 
+```bash
+# 의존성 설치
+pnpm install
 
-## 정적 파일로 구동
+# 개발 서버 실행 (port 3000)
+pnpm dev
 
-1. [https://pudding.camp/~/fastapi-book1-54](https://pudding.camp/~/fastapi-book1-54) URL에 접속해
-파일을 내려받습니다.
-2. 다음 과정을 터미널에서 진행합니다.
-3. 압축 해제
-4. 압축 해제한 파일 있는 경로로 진입
-5. `python3 -m http.server 5173`
+# 프로덕션 빌드
+pnpm build
 
-이제 Front-end에는 `http://localhost:5173`으로 접속합니다. 해당 Front-end는 `http://localhost:8000`을 개발 서버로 접근합니다.
+# 테스트 실행
+pnpm test
 
-
----
-
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+# 린트 검사
+pnpm lint
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+## 프로젝트 구조
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
-
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+```
+src/
+├── components/   # 재사용 컴포넌트
+├── pages/        # 페이지 컴포넌트
+├── hooks/        # Custom Hooks
+├── routes/       # 라우트 정의
+└── libs/         # 유틸리티
 ```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,14 +1,14 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" sizes="32x32" href="https://cdn.puddingcamp.com/static/appicons/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="https://cdn.puddingcamp.com/static/appicons/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="https://cdn.puddingcamp.com/static/appicons/favicon-16x16.png">
-    <meta property="og:site_name" content="PuddingCamp">
-    <meta property="og:url" content="https://puddingcamp.com/">   
+    <link rel="icon" href="/favicon.ico" />
+    <meta property="og:site_name" content="cohi-chat">
+    <meta property="og:url" content="https://github.com/CheHyeonYeong/cohi-chat">
+    <meta property="og:title" content="cohi-chat - 1:1 미팅 예약 서비스">
+    <meta property="og:description" content="호스트-게스트 간 미팅 예약 웹 서비스">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>푸딩캠프 약속잡기 캘린더</title>
+    <title>cohi-chat</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #167

---

## 📦 뭘 만들었나요? (What)

프로젝트에서 푸딩캠프(PuddingCamp) 관련 내용을 제거하고 cohi-chat 브랜딩으로 변경했습니다.

- `frontend/index.html`: favicon, og tags, title 변경
- `frontend/README.md`: 프로젝트에 맞게 재작성

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

기존 푸딩캠프 템플릿에서 시작한 프로젝트이므로, 독립적인 프로젝트로 브랜딩을 정리할 필요가 있었습니다. favicon은 외부 CDN 의존성을 제거하고 로컬 favicon.ico를 사용하도록 변경했습니다.

---

## 어떻게 테스트했나요? (Test)

- pnpm build 실행하여 dist/index.html에 변경사항 반영 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 개발 서버 실행 후 브라우저 탭 title이 "cohi-chat"으로 표시되는지 확인
2. 페이지 소스에서 og:site_name, og:url 등이 cohi-chat으로 변경되었는지 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

favicon.ico 파일은 아직 없으므로, 추후 로고 디자인 시 추가 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 프로젝트 README 문서를 현대화하고 재구성했습니다. 기술 스택, 개발 명령어, 프로젝트 구조 개요를 추가했습니다.
  * 페이지 제목을 "cohi-chat"으로 변경했습니다.
  * 문서 언어를 한국어로 설정했습니다.
  * Open Graph 메타데이터를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->