### PR TITLE
fix: #163 홈 화면 로그인/로그아웃 버튼 조건부 표시

### DIFF
--- a/frontend/src/pages/main/Home.tsx
+++ b/frontend/src/pages/main/Home.tsx
@@ -1,24 +1,26 @@
 import { Link } from '@tanstack/react-router';
 import { useHosts } from '~/hooks/useHost';
 import { LogoutButton } from '~/components/button/LogoutButton';
+import { useAuth } from '~/features/member';
 
 export default function Home() {
     const hosts = useHosts();
+    const { isAuthenticated } = useAuth();
     const now = new Date();
 
     return (
         <div className='w-6/12 mx-auto flex flex-col justify-center min-h-[200px] px-8 space-y-4'>
             <div className='flex justify-between items-center'>
                 <h1 className='text-2xl font-bold'>약속 잡기 서비스</h1>
-                {hosts.data && <LogoutButton />}
+                {isAuthenticated
+                    ? <LogoutButton />
+                    : <Link to='/app/login' className='bg-primary text-white px-4 py-2 rounded-md hover:bg-secondary hover:text-white'>로그인</Link>
+                }
             </div>
 
             {hosts.isLoading && <div>읽어오는 중...</div>}
             {hosts.error && <div className='space-y-2'>
                 <p className='text-red-500'>{hosts.error.message}</p>
-                {hosts.error.cause === 401 && <p className=''>
-                    <Link to='/app/login' className='block text-center bg-primary text-white px-4 py-2 rounded-md hover:bg-secondary hover:text-white'>로그인</Link>
-                </p>}
             </div>}
 
             <ul>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #163

---

## 📦 뭘 만들었나요? (What)

홈 화면에서 인증 상태에 따라 로그인/로그아웃 버튼을 조건부로 표시하도록 수정
- 비로그인 상태: 로그인 버튼 표시
- 로그인 상태: 로그아웃 버튼 표시
- 기존 401 에러 영역 내 로그인 링크 제거

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

기존에는 `hosts.data` 존재 여부(API 호출 성공)로 로그아웃 버튼 표시를 판단하고, 로그인 링크는 401 에러 발생 시에만 에러 메시지 안에서 보여주고 있었음. `useAuth()` 훅의 `isAuthenticated`를 사용하면 API 응답에 의존하지 않고 JWT 토큰 기반으로 인증 상태를 즉시 판단할 수 있어 이 방식을 선택함.

---

## 어떻게 테스트했나요? (Test)

TypeScript 타입 체크 통과 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 비로그인 상태에서 홈 화면 진입 시 로그인 버튼 표시 확인
2. 로그인 버튼 클릭 시 `/app/login`으로 이동 확인
3. 로그인 후 홈 화면에서 로그아웃 버튼 표시 확인
4. 로그아웃 버튼 클릭 시 로그인 버튼으로 전환 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 수정 파일: `frontend/src/pages/main/Home.tsx` 1개
- 프로덕션 빌드 시 `calendar.less` 관련 에러는 기존 이슈로 이번 변경과 무관