### PR TITLE
chore: #89 .env.example 환경변수 가이드 제공

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,12 +20,15 @@ REDIS_PORT=6379
 # Google Calendar API
 # -------------------------------------------
 GOOGLE_CALENDAR_ID=your_google_calendar_id
+# 서비스 계정 크레덴셜 JSON 파일을 backend/ 디렉토리에 배치 필요
+# 파일명: calendar-booking-service-account-credentials.json
 
 # -------------------------------------------
 # AWS
 # -------------------------------------------
 AWS_ACCESS_KEY_ID=your_aws_access_key
 AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AWS_REGION=ap-northeast-2
 
 # -------------------------------------------
 # Frontend


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #89

---

## 📦 뭘 만들었나요? (What)

프로젝트 루트에 `.env.example` 파일을 추가하여 필요한 환경변수 목록과 형식을 제공
- JWT, Redis, Google Calendar API, AWS, Frontend API URL 설정 포함
- Google Calendar 서비스 계정 크레덴셜 JSON 파일 배치 안내 포함

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

이슈에서 제시된 예시는 PostgreSQL 기반이었으나, 실제 프로젝트는 SQLite를 사용하고 있어 DB 관련 환경변수는 불필요함. `application.properties`와 `docker-compose.prod.yml`, 프론트엔드 소스에서 실제 사용 중인 환경변수(`${VAR}`, `import.meta.env.VITE_*`)만 추출하여 작성함.

---

## 어떻게 테스트했나요? (Test)

- `.gitignore`에 `.env`가 이미 포함되어 있어 실제 `.env` 파일이 커밋되지 않음을 확인
- `.env.example`은 템플릿이므로 민감 정보 미포함 확인

---

## 참고사항 / 회고 메모 (Notes)

- 수정 파일 1개: `.env.example` (신규 생성)