### PR TITLE
fix: #190 Docker Volume 설정으로 SQLite 데이터 영속성 확보

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=cohiChat
 
 spring.datasource.driver-class-name=org.sqlite.JDBC
-spring.datasource.url=jdbc:sqlite:./cohi-chat.db
+spring.datasource.url=jdbc:sqlite:${SQLITE_DB_PATH:./cohi-chat.db}
 
 spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
 spring.jpa.hibernate.ddl-auto=update

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-devpassword}
-      # Add your environment variables here
-      # - DB_URL=jdbc:postgresql://db:5432/cohichat
-      # - DB_USERNAME=cohichat
-      # - DB_PASSWORD=your_password
+      - SQLITE_DB_PATH=/app/data/cohi-chat.db
+    volumes:
+      - sqlite-data:/app/data
     networks:
       - cohi-chat-network
     depends_on:
@@ -74,6 +73,8 @@ networks:
 
 volumes:
   redis-data:
+    driver: local
+  sqlite-data:
     driver: local
   # Uncomment if you need persistent volumes
   # postgres-data:


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #190

---

## 📦 뭘 만들었나요? (What)

Docker 컨테이너 재시작 시에도 SQLite 데이터가 유지되도록 Volume 설정을 추가했습니다.

- `docker-compose.yml`에 `sqlite-data` named volume 정의
- backend 서비스에 `/app/data` 볼륨 마운트
- `application.properties`에서 환경 변수로 DB 경로 설정 가능하도록 수정

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. **Bind Mount vs Named Volume**
   - Bind Mount: 호스트 경로 직접 지정, 호스트 의존성 발생
   - Named Volume: Docker가 관리, 이식성 좋음
   - → **Named Volume** 선택 (배포 환경에서 관리 용이)

2. **환경 변수 사용**
   - 로컬 개발: 기본값 `./cohi-chat.db` 사용
   - Docker 환경: `SQLITE_DB_PATH=/app/data/cohi-chat.db` 주입
   - → 개발/운영 환경 모두 호환

---

## 어떻게 테스트했나요? (Test)

- 로컬 개발 환경에서 기존 경로로 정상 동작 확인
- Docker 환경에서는 수동 테스트 필요 (CP4)

<details>
<summary>테스트 시나리오</summary>

1. `docker-compose up -d`로 서비스 시작
2. 회원가입/로그인으로 데이터 생성
3. `docker-compose down && docker-compose up -d`로 재시작
4. 로그인하여 데이터 유지 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 이 수정은 임시 해결책입니다
- 장기적으로는 #86 PostgreSQL 마이그레이션을 권장합니다
- Docker 환경에서 실제 테스트 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 데이터베이스 저장 경로를 환경 변수로 설정 가능하도록 개선했습니다.
  * 데이터 지속성을 강화하기 위해 저장소 마운팅 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->