### PR TITLE
feat: #199 Footer 컴포넌트 추가

### DIFF
--- a/frontend/src/components/Footer.test.tsx
+++ b/frontend/src/components/Footer.test.tsx
@@ -23,9 +23,9 @@ describe('Footer', () => {
         const currentYear = new Date().getFullYear();
 
         const copyrightText = container.textContent;
-        expect(copyrightText).toContain('Copyright');
         expect(copyrightText).toContain(`${currentYear}`);
         expect(copyrightText).toContain('coheChat');
+        expect(copyrightText).toContain('All rights reserved');
     });
 
     it('should render terms of service link', () => {
@@ -34,7 +34,7 @@ describe('Footer', () => {
         const termsLink = Array.from(container.querySelectorAll('a')).find(
             (link) => link.textContent === '이용약관'
         );
-        expect(termsLink).toBeDefined();
+        expect(termsLink).toBeTruthy();
     });
 
     it('should render privacy policy link', () => {
@@ -43,13 +43,13 @@ describe('Footer', () => {
         const privacyLink = Array.from(container.querySelectorAll('a')).find(
             (link) => link.textContent === '개인정보처리방침'
         );
-        expect(privacyLink).toBeDefined();
+        expect(privacyLink).toBeTruthy();
     });
 
     it('should have footer element', () => {
         const { container } = render(<Footer />);
 
         const footer = container.querySelector('footer');
-        expect(footer).toBeDefined();
+        expect(footer).toBeTruthy();
     });
 });

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -4,29 +4,61 @@ export default function Footer() {
     const currentYear = new Date().getFullYear();
 
     return (
-        <footer className="w-full bg-[var(--cohe-bg-warm)] border-t border-gray-200">
-            <div className="max-w-7xl mx-auto px-6 py-8">
-                <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-                    {/* Copyright */}
-                    <div className="text-sm text-gray-600">
-                        Copyright &copy; {currentYear} coheChat
+        <footer className="w-full bg-slate-900">
+            {/* Main Footer Content */}
+            <div className="max-w-7xl mx-auto px-6 py-12">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                    {/* Brand Section */}
+                    <div>
+                        <h3 className="text-white font-bold text-lg mb-4">coheChat</h3>
+                        <p className="text-gray-400 text-sm leading-relaxed">
+                            1:1 미팅 예약을 간편하게.<br />
+                            Google Calendar와 연동하여<br />
+                            일정을 효율적으로 관리하세요.
+                        </p>
                     </div>
 
-                    {/* Service Links */}
-                    <nav className="flex gap-6">
-                        <Link
-                            to="/app"
-                            className="text-sm text-gray-600 hover:text-[var(--cohe-primary)] transition-colors"
-                        >
-                            이용약관
-                        </Link>
-                        <Link
-                            to="/app"
-                            className="text-sm text-gray-600 hover:text-[var(--cohe-primary)] transition-colors"
-                        >
-                            개인정보처리방침
-                        </Link>
-                    </nav>
+                    {/* Quick Links */}
+                    <div>
+                        <h3 className="text-white font-bold text-lg mb-4">바로가기</h3>
+                        <nav className="flex flex-col gap-3">
+                            <Link
+                                to="/app"
+                                className="text-gray-400 text-sm hover:text-white transition-colors"
+                            >
+                                홈
+                            </Link>
+                            <Link
+                                to="/terms"
+                                className="text-gray-400 text-sm hover:text-white transition-colors"
+                            >
+                                이용약관
+                            </Link>
+                            <Link
+                                to="/privacy"
+                                className="text-gray-400 text-sm hover:text-white transition-colors"
+                            >
+                                개인정보처리방침
+                            </Link>
+                        </nav>
+                    </div>
+
+                    {/* Contact */}
+                    <div>
+                        <h3 className="text-white font-bold text-lg mb-4">Contact</h3>
+                        <p className="text-gray-400 text-sm">
+                            문의 및 피드백은 언제든 환영합니다.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            {/* Copyright Bar */}
+            <div className="border-t border-slate-700">
+                <div className="max-w-7xl mx-auto px-6 py-6">
+                    <p className="text-center text-gray-500 text-sm">
+                        &copy; {currentYear} coheChat. All rights reserved.
+                    </p>
                 </div>
             </div>
         </footer>

--- a/frontend/src/pages/legal/Privacy.tsx
+++ b/frontend/src/pages/legal/Privacy.tsx
@@ -1,0 +1,83 @@
+import { Link } from '@tanstack/react-router';
+
+export default function Privacy() {
+    return (
+        <div className="min-h-screen bg-white">
+            <div className="max-w-4xl mx-auto px-6 py-16">
+                <Link
+                    to="/app"
+                    className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 mb-8 transition-colors"
+                >
+                    <span>&larr;</span>
+                    <span>홈으로 돌아가기</span>
+                </Link>
+                <h1 className="text-3xl font-bold text-gray-900 mb-8">개인정보처리방침</h1>
+
+                <div className="prose prose-gray max-w-none space-y-8">
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">1. 수집하는 개인정보</h2>
+                        <p className="text-gray-600 leading-relaxed mb-4">
+                            coheChat은 서비스 제공을 위해 다음과 같은 개인정보를 수집합니다.
+                        </p>
+                        <ul className="list-disc list-inside text-gray-600 space-y-2">
+                            <li>필수항목: 이메일 주소, 이름</li>
+                            <li>선택항목: 프로필 이미지</li>
+                            <li>자동수집: 서비스 이용 기록, 접속 로그</li>
+                        </ul>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">2. 개인정보의 이용 목적</h2>
+                        <ul className="list-disc list-inside text-gray-600 space-y-2">
+                            <li>회원 식별 및 서비스 제공</li>
+                            <li>미팅 예약 및 일정 관리</li>
+                            <li>Google Calendar 연동</li>
+                            <li>서비스 개선 및 통계 분석</li>
+                        </ul>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">3. 개인정보의 보관 및 파기</h2>
+                        <p className="text-gray-600 leading-relaxed">
+                            회원 탈퇴 시 개인정보는 즉시 파기됩니다.
+                            단, 관련 법령에 따라 보관이 필요한 경우 해당 기간 동안 보관 후 파기합니다.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">4. 개인정보의 제3자 제공</h2>
+                        <p className="text-gray-600 leading-relaxed">
+                            coheChat은 원칙적으로 회원의 개인정보를 제3자에게 제공하지 않습니다.
+                            다만, 회원의 동의가 있거나 법령에 의한 경우에는 예외로 합니다.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">5. 이용자의 권리</h2>
+                        <ul className="list-disc list-inside text-gray-600 space-y-2">
+                            <li>개인정보 열람, 정정, 삭제 요청</li>
+                            <li>개인정보 처리 정지 요청</li>
+                            <li>회원 탈퇴</li>
+                        </ul>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">6. 개인정보 보호책임자</h2>
+                        <p className="text-gray-600 leading-relaxed">
+                            개인정보 처리에 관한 문의사항은 아래 연락처로 문의해 주시기 바랍니다.
+                        </p>
+                        <p className="text-gray-600 mt-2">
+                            이메일: support@cohechat.com
+                        </p>
+                    </section>
+
+                    <div className="pt-8 border-t border-gray-200">
+                        <p className="text-sm text-gray-500">
+                            시행일: 2026년 1월 1일
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/legal/Terms.tsx
+++ b/frontend/src/pages/legal/Terms.tsx
@@ -1,0 +1,69 @@
+import { Link } from '@tanstack/react-router';
+
+export default function Terms() {
+    return (
+        <div className="min-h-screen bg-white">
+            <div className="max-w-4xl mx-auto px-6 py-16">
+                <Link
+                    to="/app"
+                    className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 mb-8 transition-colors"
+                >
+                    <span>&larr;</span>
+                    <span>홈으로 돌아가기</span>
+                </Link>
+                <h1 className="text-3xl font-bold text-gray-900 mb-8">이용약관</h1>
+
+                <div className="prose prose-gray max-w-none space-y-8">
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">제1조 (목적)</h2>
+                        <p className="text-gray-600 leading-relaxed">
+                            이 약관은 coheChat(이하 "서비스")이 제공하는 1:1 미팅 예약 서비스의 이용조건 및
+                            절차에 관한 사항을 규정함을 목적으로 합니다.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">제2조 (정의)</h2>
+                        <ul className="list-disc list-inside text-gray-600 space-y-2">
+                            <li>"서비스"란 coheChat이 제공하는 미팅 예약 및 일정 관리 서비스를 말합니다.</li>
+                            <li>"회원"이란 서비스에 가입하여 이용하는 자를 말합니다.</li>
+                            <li>"호스트"란 미팅 일정을 공개하고 예약을 받는 회원을 말합니다.</li>
+                            <li>"게스트"란 호스트의 일정에 예약을 신청하는 회원을 말합니다.</li>
+                        </ul>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">제3조 (서비스 이용)</h2>
+                        <p className="text-gray-600 leading-relaxed">
+                            회원은 서비스를 통해 Google Calendar와 연동하여 미팅 일정을 관리하고,
+                            다른 회원과 1:1 미팅을 예약할 수 있습니다.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">제4조 (회원의 의무)</h2>
+                        <ul className="list-disc list-inside text-gray-600 space-y-2">
+                            <li>회원은 정확한 정보를 제공해야 합니다.</li>
+                            <li>회원은 예약한 미팅에 성실히 참여해야 합니다.</li>
+                            <li>회원은 타인의 권리를 침해하는 행위를 해서는 안 됩니다.</li>
+                        </ul>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-800 mb-4">제5조 (서비스 변경 및 중단)</h2>
+                        <p className="text-gray-600 leading-relaxed">
+                            서비스는 운영상 필요한 경우 사전 공지 후 서비스 내용을 변경하거나
+                            일시적으로 중단할 수 있습니다.
+                        </p>
+                    </section>
+
+                    <div className="pt-8 border-t border-gray-200">
+                        <p className="text-sm text-gray-500">
+                            시행일: 2026년 1월 1일
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -11,6 +11,8 @@ import Home from '~/pages/main/Home'
 import MyBookings from '~/pages/calendar/MyBookings'
 import Booking from '~/pages/calendar/Booking'
 import Footer from '~/components/Footer'
+import Terms from '~/pages/legal/Terms'
+import Privacy from '~/pages/legal/Privacy'
 
 const RootRoute = createRootRoute({
     component: () => {
@@ -90,6 +92,18 @@ const calendarRoute = createRoute({
     }),
 })
 
+const termsRoute = createRoute({
+    getParentRoute: () => RootRoute,
+    path: '/terms',
+    component: Terms,
+})
+
+const privacyRoute = createRoute({
+    getParentRoute: () => RootRoute,
+    path: '/privacy',
+    component: Privacy,
+})
+
 export const routeTree = RootRoute.addChildren([
     indexRoute,
     homeRoute,
@@ -98,6 +112,8 @@ export const routeTree = RootRoute.addChildren([
     signupRoute,
     myBookingsRoute,
     bookingRoute,
+    termsRoute,
+    privacyRoute,
 ])
 
 export const router = createRouter({ routeTree })


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #199

---

## 📦 뭘 만들었나요? (What)

서비스 하단에 표시될 Footer 컴포넌트를 제작했습니다.

- `Footer.tsx` 컴포넌트 생성
- 저작권 표시: `Copyright © {year} coheChat`
- 서비스 링크: 이용약관, 개인정보처리방침
- 반응형 디자인 (Tailwind CSS)
- `__root.tsx` 레이아웃에 통합

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. **레이아웃 구조**
   - flex-col + min-h-screen으로 Footer가 항상 하단에 위치
   - 콘텐츠가 짧아도 Footer는 화면 하단에 고정

2. **스타일**
   - 기존 프로젝트 CSS 변수 활용 (`--cohe-bg-warm`, `--cohe-primary`)
   - 일관된 디자인 유지

---

## 어떻게 테스트했나요? (Test)

- 테스트 코드 작성 및 통과 (4개 테스트)
- `pnpm build` 성공

<details>
<summary>테스트 시나리오</summary>

1. 저작권 텍스트 렌더링 확인
2. 이용약관 링크 렌더링 확인
3. 개인정보처리방침 링크 렌더링 확인
4. footer 요소 존재 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 이용약관/개인정보처리방침 페이지 내용은 별도 이슈로 작성 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 반응형 푸터 추가(브랜드·빠른 링크·문의 섹션 및 저작권 바 포함)
  * 현재 연도 자동 표시 및 홈페이지, 이용약관(/terms), 개인정보처리방침(/privacy) 링크 제공
  * 이용약관·개인정보처리방침 페이지 추가

* **테스트**
  * 푸터 렌더링과 주요 요소(푸터 존재, 연도·사이트명, 이용약관·개인정보처리방침 링크)를 검증하는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->