### PR TITLE
feat: #198 회원가입/로그인 Form UX 개선

### DIFF
--- a/frontend/src/features/member/hooks/useFormValidation.ts
+++ b/frontend/src/features/member/hooks/useFormValidation.ts
@@ -1,0 +1,116 @@
+import { useState, useCallback } from 'react';
+
+export type ValidationRule<T> = (value: T) => string | null;
+
+export interface FieldState {
+    touched: boolean;
+    error: string | null;
+    isValid: boolean;
+}
+
+export interface UseFormValidationReturn<T extends object> {
+    fields: Record<keyof T, FieldState>;
+    validateField: (name: keyof T, value: T[keyof T]) => string | null;
+    handleBlur: (name: keyof T, value: T[keyof T]) => void;
+    validateAll: (values: T) => boolean;
+    resetValidation: () => void;
+    getInputClassName: (name: keyof T, baseClass?: string) => string;
+}
+
+const defaultFieldState: FieldState = {
+    touched: false,
+    error: null,
+    isValid: false,
+};
+
+export function useFormValidation<T extends object>(
+    rules: Partial<Record<keyof T, ValidationRule<T[keyof T]>>>
+): UseFormValidationReturn<T> {
+    const [fields, setFields] = useState<Record<keyof T, FieldState>>(() => {
+        const initial = {} as Record<keyof T, FieldState>;
+        for (const key of Object.keys(rules) as (keyof T)[]) {
+            initial[key] = { ...defaultFieldState };
+        }
+        return initial;
+    });
+
+    const validateField = useCallback(
+        (name: keyof T, value: T[keyof T]): string | null => {
+            const rule = rules[name];
+            if (!rule) return null;
+            return rule(value);
+        },
+        [rules]
+    );
+
+    const handleBlur = useCallback(
+        (name: keyof T, value: T[keyof T]) => {
+            const error = validateField(name, value);
+            setFields((prev) => ({
+                ...prev,
+                [name]: {
+                    touched: true,
+                    error,
+                    isValid: error === null,
+                },
+            }));
+        },
+        [validateField]
+    );
+
+    const validateAll = useCallback(
+        (values: T): boolean => {
+            const newFields = {} as Record<keyof T, FieldState>;
+            let allValid = true;
+
+            for (const key of Object.keys(rules) as (keyof T)[]) {
+                const error = validateField(key, values[key]);
+                newFields[key] = {
+                    touched: true,
+                    error,
+                    isValid: error === null,
+                };
+                if (error !== null) {
+                    allValid = false;
+                }
+            }
+
+            setFields(newFields);
+            return allValid;
+        },
+        [rules, validateField]
+    );
+
+    const resetValidation = useCallback(() => {
+        setFields(() => {
+            const reset = {} as Record<keyof T, FieldState>;
+            for (const key of Object.keys(rules) as (keyof T)[]) {
+                reset[key] = { ...defaultFieldState };
+            }
+            return reset;
+        });
+    }, [rules]);
+
+    const getInputClassName = useCallback(
+        (name: keyof T, baseClass = ''): string => {
+            const field = fields[name];
+            if (!field?.touched) {
+                return `${baseClass} border-gray-300 focus:border-[var(--cohe-primary)]`;
+            }
+            if (field.error) {
+                return `${baseClass} border-red-500 focus:border-red-500`;
+            }
+            return `${baseClass} border-green-500 focus:border-green-500`;
+        },
+        [fields]
+    );
+
+    return {
+        fields,
+        validateField,
+        handleBlur,
+        validateAll,
+        resetValidation,
+        getInputClassName,
+    };
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #198

---

## 📦 뭘 만들었나요? (What)

회원가입 및 로그인 폼의 사용자 경험(UX)을 개선했습니다.

- `useFormValidation` 커스텀 훅 생성 (재사용 가능)
- onBlur 시점에 validation 메시지 노출
- 에러/성공 상태에 따른 시각적 피드백 (border color)
- 회원가입 성공 후 즉시 페이지 이동 (기존 1.5초 딜레이 제거)

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. **Validation 타이밍**
   - onChange: 너무 잦은 피드백으로 UX 저하
   - onBlur: 필드 입력 완료 시점에 검증하여 적절한 피드백
   - → **onBlur** 선택

2. **시각적 피드백**
   - 에러: `border-red-500` (빨간색)
   - 성공: `border-green-500` (초록색)
   - 사용자가 직관적으로 상태 인식 가능

3. **페이지 이동 딜레이 제거**
   - 기존 1.5초 딜레이는 불필요한 대기 시간
   - 즉시 이동으로 UX 개선

---

## 어떻게 테스트했나요? (Test)

- `pnpm build` 성공 확인
- 로컬에서 로그인/회원가입 폼 동작 확인

---

## 참고사항 / 회고 메모 (Notes)

- debounce 적용은 추후 개선 가능
- 테스트 코드 추가 작성 필요 (CP에 표시)