### PR TITLE
fix: 캘린더 요일 매핑 규칙 통일 (ISO→JS Date.getDay)

### DIFF
--- a/frontend/src/features/calendar/components/Body/Body.tsx
+++ b/frontend/src/features/calendar/components/Body/Body.tsx
@@ -47,7 +47,7 @@ export default function Body({ year, month, days, baseDate, timeslots, bookings,
                     {weeks.map((week, weekIndex) => (
                         <tr key={weekIndex} className="grid grid-cols-7 gap-4">
                             {week.map((day, dayIndex) => {
-                                const weekday = dayIndex === 0 ? 6 : dayIndex - 1;
+                                const weekday = dayIndex; // 0=일, 1=월, ..., 6=토 (Date.getDay() 규칙)
                                 const isAvailable = checkAvailableBookingDate(now, timeslots, bookings, year, month, day, weekday);
 
                                 return (

--- a/frontend/src/features/calendar/components/Timeslots/Timeslots.tsx
+++ b/frontend/src/features/calendar/components/Timeslots/Timeslots.tsx
@@ -18,7 +18,7 @@ export default function Timeslots({ baseDate, timeslots, bookings, onSelectTimes
     const { data: user } = useAuth();
 
     const now = baseDate ?? new Date();
-    const weekday = now.getDay() === 0 ? 6 : now.getDay() - 1;
+    const weekday = now.getDay(); // 0=일, 1=월, ..., 6=토
     const isAvailable = checkAvailableBookingDate(now, timeslots, bookings, now.getFullYear(), now.getMonth() + 1, now.getDate(), weekday);
 
     return <Suspense fallback={<div>Loading timeslots...</div>}>

--- a/frontend/src/features/calendar/utils/checkAvailableBookingDate.ts
+++ b/frontend/src/features/calendar/utils/checkAvailableBookingDate.ts
@@ -10,7 +10,6 @@ export function checkAvailableBookingDate(
     weekday: number
 ): boolean {
     const isUnavailable =
-        (weekday === 5 || weekday === 6) ||
         (year < baseDate.getFullYear() ||
             (year === baseDate.getFullYear() && month < baseDate.getMonth() + 1)) ||
         (year === baseDate.getFullYear() &&


### PR DESCRIPTION
## Summary
- 캘린더 UI에서 요일 매핑이 ISO 규칙(월=0, 일=6)을 사용하여, JS Date.getDay() 규칙(일=0, 토=6)으로 저장된 타임슬롯 weekdays와 불일치
- 이로 인해 캘린더에서 모든 날짜가 선택 불가로 표시되어 커피챗 예약 불가
- `checkAvailableBookingDate`의 하드코딩된 주말 차단(weekday 5,6) 제거 — 타임슬롯 설정에 따라 자동 판단

## 변경 파일
- `Body.tsx`: `dayIndex === 0 ? 6 : dayIndex - 1` → `dayIndex`
- `Timeslots.tsx`: `now.getDay() === 0 ? 6 : now.getDay() - 1` → `now.getDay()`
- `checkAvailableBookingDate.ts`: 주말 하드코딩 제거

## Test plan
- [ ] 캘린더 페이지에서 타임슬롯이 설정된 요일의 날짜 선택 가능 확인
- [ ] 타임슬롯이 없는 요일은 선택 불가 확인
- [ ] 과거 날짜 선택 불가 확인
- [ ] 호스트가 주말 타임슬롯 설정 시 주말 날짜 선택 가능 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캘린더 예약 가능 여부 확인 로직을 수정했습니다. 주중과 주말의 요일 계산을 표준화했으며, 주말에 대한 자동 제한을 제거하여 더 유연한 예약 스케줄링을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->