### PR TITLE
feat: #226 비밀번호 재설정 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // Bucket4j Rate Limiting
     implementation 'com.bucket4j:bucket4j_jdk17-core:8.14.0'

--- a/backend/src/main/java/com/coDevs/cohiChat/email/EmailService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/email/EmailService.java
@@ -1,0 +1,5 @@
+package com.coDevs.cohiChat.email;
+
+public interface EmailService {
+    void sendPasswordResetEmail(String to, String resetLink);
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/email/EmailServiceImpl.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/email/EmailServiceImpl.java
@@ -1,0 +1,83 @@
+package com.coDevs.cohiChat.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender mailSender;
+    private final String fromEmail;
+
+    public EmailServiceImpl(
+            JavaMailSender mailSender,
+            @Value("${spring.mail.username:noreply@cohichat.com}") String fromEmail) {
+        this.mailSender = mailSender;
+        this.fromEmail = fromEmail;
+    }
+
+    @Override
+    public void sendPasswordResetEmail(String to, String resetLink) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(fromEmail);
+            helper.setTo(to);
+            helper.setSubject("[CoHi Chat] 비밀번호 재설정");
+            helper.setText(buildPasswordResetEmailContent(resetLink), true);
+
+            mailSender.send(message);
+            log.info("Password reset email sent to: {}", to);
+        } catch (MessagingException e) {
+            log.error("Failed to send password reset email to: {}", to, e);
+        } catch (Exception e) {
+            log.error("Unexpected error while sending password reset email to: {}", to, e);
+        }
+    }
+
+    private String buildPasswordResetEmailContent(String resetLink) {
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <style>
+                    body { font-family: 'Noto Sans KR', Arial, sans-serif; line-height: 1.6; color: #333; }
+                    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+                    .header { background-color: #4F46E5; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+                    .content { background-color: #f9fafb; padding: 30px; border-radius: 0 0 8px 8px; }
+                    .button { display: inline-block; background-color: #4F46E5; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 20px 0; }
+                    .footer { margin-top: 20px; font-size: 12px; color: #666; }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <div class="header">
+                        <h1>CoHi Chat</h1>
+                    </div>
+                    <div class="content">
+                        <h2>비밀번호 재설정</h2>
+                        <p>안녕하세요,</p>
+                        <p>비밀번호 재설정을 요청하셨습니다. 아래 버튼을 클릭하여 새 비밀번호를 설정해주세요.</p>
+                        <p style="text-align: center;">
+                            <a href="%s" class="button">비밀번호 재설정</a>
+                        </p>
+                        <p>이 링크는 30분 후에 만료됩니다.</p>
+                        <p>만약 비밀번호 재설정을 요청하지 않으셨다면, 이 이메일을 무시해주세요.</p>
+                        <div class="footer">
+                            <p>이 이메일은 자동으로 발송되었습니다. 회신하지 마세요.</p>
+                        </div>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """.formatted(resetLink);
+    }
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 인증 토큰입니다."),
 	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
 	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
+	INVALID_RESET_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 비밀번호 재설정 토큰입니다."),
 	AUTH_NOT_PROVIDED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
 
 	ALREADY_HOST(HttpStatus.CONFLICT, "이미 호스트로 등록되어 있습니다."),

--- a/backend/src/main/java/com/coDevs/cohiChat/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/global/security/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/swagger-ui/**", "/hello", "/api/hello", "/members/v1/signup", "/members/v1/login", "/members/v1/refresh", "/members/v1/hosts", "/timeslot/v1/hosts/**").permitAll()
+				.requestMatchers("/swagger-ui/**", "/hello", "/api/hello", "/members/v1/signup", "/members/v1/login", "/members/v1/refresh", "/members/v1/hosts", "/members/v1/password-reset/**", "/timeslot/v1/hosts/**").permitAll()
 				// /calendar/v1 엔드포인트는 인증 필수 (permitAll 규칙보다 먼저 적용)
 				.requestMatchers("/calendar/v1", "/calendar/v1/**").authenticated()
 				// 공개 캘린더 엔드포인트 (slug 기반)

--- a/backend/src/main/java/com/coDevs/cohiChat/member/MemberRepository.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/MemberRepository.java
@@ -18,6 +18,8 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
 
 	boolean existsByEmail(String email);
 
+	Optional<Member> findByEmailAndIsDeletedFalse(String email);
+
 	Optional<Member> findByIdAndRoleAndIsDeletedFalse(UUID id, Role role);
 
 	java.util.List<Member> findByRoleAndIsDeletedFalse(Role role);

--- a/backend/src/main/java/com/coDevs/cohiChat/member/PasswordResetController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/PasswordResetController.java
@@ -1,0 +1,38 @@
+package com.coDevs.cohiChat.member;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coDevs.cohiChat.member.request.PasswordResetConfirmDTO;
+import com.coDevs.cohiChat.member.request.PasswordResetRequestDTO;
+import com.coDevs.cohiChat.member.response.PasswordResetResponseDTO;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/members/v1/password-reset")
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    @PostMapping("/request")
+    public ResponseEntity<PasswordResetResponseDTO> requestPasswordReset(
+            @Valid @RequestBody PasswordResetRequestDTO request) {
+
+        passwordResetService.requestPasswordReset(request.getEmail());
+        return ResponseEntity.ok(PasswordResetResponseDTO.requestSent());
+    }
+
+    @PostMapping("/confirm")
+    public ResponseEntity<PasswordResetResponseDTO> confirmPasswordReset(
+            @Valid @RequestBody PasswordResetConfirmDTO request) {
+
+        passwordResetService.resetPassword(request.getToken(), request.getNewPassword());
+        return ResponseEntity.ok(PasswordResetResponseDTO.resetSuccess());
+    }
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/member/PasswordResetService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/PasswordResetService.java
@@ -1,0 +1,93 @@
+package com.coDevs.cohiChat.member;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coDevs.cohiChat.email.EmailService;
+import com.coDevs.cohiChat.global.exception.CustomException;
+import com.coDevs.cohiChat.global.exception.ErrorCode;
+import com.coDevs.cohiChat.member.entity.Member;
+import com.coDevs.cohiChat.member.entity.PasswordResetToken;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class PasswordResetService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
+    private final String baseUrl;
+    private final long tokenExpirationMinutes;
+
+    public PasswordResetService(
+            MemberRepository memberRepository,
+            PasswordResetTokenRepository passwordResetTokenRepository,
+            PasswordEncoder passwordEncoder,
+            EmailService emailService,
+            @Value("${password-reset.base-url}") String baseUrl,
+            @Value("${password-reset.token-expiration-minutes}") long tokenExpirationMinutes) {
+        this.memberRepository = memberRepository;
+        this.passwordResetTokenRepository = passwordResetTokenRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.emailService = emailService;
+        this.baseUrl = baseUrl;
+        this.tokenExpirationMinutes = tokenExpirationMinutes;
+    }
+
+    public void requestPasswordReset(String email) {
+        // 보안: 이메일 존재 여부와 관계없이 동일한 응답 반환
+        Optional<Member> memberOpt = memberRepository.findByEmailAndIsDeletedFalse(email.toLowerCase());
+
+        if (memberOpt.isEmpty()) {
+            log.debug("Password reset requested for non-existent email: {}", email);
+            return;
+        }
+
+        // 기존 토큰이 있으면 삭제
+        passwordResetTokenRepository.findByEmail(email.toLowerCase())
+            .ifPresent(existingToken -> passwordResetTokenRepository.deleteById(existingToken.getToken()));
+
+        // 새 토큰 생성
+        String token = UUID.randomUUID().toString();
+        long expirationMs = tokenExpirationMinutes * 60 * 1000;
+
+        PasswordResetToken resetToken = PasswordResetToken.create(
+            token,
+            email.toLowerCase(),
+            expirationMs
+        );
+        passwordResetTokenRepository.save(resetToken);
+
+        // 이메일 발송
+        String resetLink = baseUrl + "/password-reset/confirm?token=" + token;
+        emailService.sendPasswordResetEmail(email, resetLink);
+
+        log.info("Password reset email sent for: {}", email);
+    }
+
+    @Transactional
+    public void resetPassword(String token, String newPassword) {
+        PasswordResetToken resetToken = passwordResetTokenRepository.findById(token)
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_RESET_TOKEN));
+
+        Member member = memberRepository.findByEmailAndIsDeletedFalse(resetToken.getEmail())
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 변경
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        member.updateInfo(null, encodedPassword);
+
+        // 토큰 삭제
+        passwordResetTokenRepository.deleteById(token);
+
+        log.info("Password reset completed for user: {}", member.getUsername());
+    }
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/member/PasswordResetTokenRepository.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/PasswordResetTokenRepository.java
@@ -1,0 +1,12 @@
+package com.coDevs.cohiChat.member;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.coDevs.cohiChat.member.entity.PasswordResetToken;
+
+public interface PasswordResetTokenRepository extends CrudRepository<PasswordResetToken, String> {
+
+    Optional<PasswordResetToken> findByEmail(String email);
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/member/entity/PasswordResetToken.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/entity/PasswordResetToken.java
@@ -1,0 +1,43 @@
+package com.coDevs.cohiChat.member.entity;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "passwordResetToken")
+public class PasswordResetToken {
+
+    @Id
+    private String token;
+
+    @Indexed
+    private String email;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long expiration;
+
+    @Builder
+    private PasswordResetToken(String token, String email, Long expiration) {
+        this.token = token;
+        this.email = email;
+        this.expiration = expiration;
+    }
+
+    public static PasswordResetToken create(String token, String email, Long expirationMs) {
+        return PasswordResetToken.builder()
+            .token(token)
+            .email(email)
+            .expiration(expirationMs)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/member/request/PasswordResetConfirmDTO.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/request/PasswordResetConfirmDTO.java
@@ -1,0 +1,23 @@
+package com.coDevs.cohiChat.member.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetConfirmDTO {
+
+    @NotBlank(message = "토큰은 필수입니다.")
+    private String token;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9!@#$%^&*._-]{8,20}$",
+        message = "비밀번호는 영문, 숫자, 특수문자(!@#$%^&*._-)를 포함한 8~20자여야 합니다."
+    )
+    private String newPassword;
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/member/request/PasswordResetRequestDTO.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/request/PasswordResetRequestDTO.java
@@ -1,0 +1,17 @@
+package com.coDevs.cohiChat.member.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequestDTO {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/backend/src/main/java/com/coDevs/cohiChat/member/response/PasswordResetResponseDTO.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/response/PasswordResetResponseDTO.java
@@ -1,0 +1,18 @@
+package com.coDevs.cohiChat.member.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordResetResponseDTO {
+    private String message;
+
+    public static PasswordResetResponseDTO requestSent() {
+        return new PasswordResetResponseDTO("비밀번호 재설정 이메일이 발송되었습니다.");
+    }
+
+    public static PasswordResetResponseDTO resetSuccess() {
+        return new PasswordResetResponseDTO("비밀번호가 성공적으로 변경되었습니다.");
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -45,3 +45,16 @@ spring.servlet.multipart.max-request-size=50MB
 # AWS S3 Configuration
 aws.region=ap-northeast-2
 aws.s3.bucket=cohi-chat-uploads
+
+# Email (SMTP)
+spring.mail.host=${MAIL_HOST:smtp.gmail.com}
+spring.mail.port=${MAIL_PORT:587}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+
+# Password Reset
+password-reset.token-expiration-minutes=30
+password-reset.base-url=${PASSWORD_RESET_BASE_URL:http://localhost:3000}

--- a/backend/src/test/java/com/coDevs/cohiChat/email/EmailServiceTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/email/EmailServiceTest.java
@@ -1,0 +1,59 @@
+package com.coDevs.cohiChat.email;
+
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private MimeMessage mimeMessage;
+
+    private EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        emailService = new EmailServiceImpl(mailSender, "noreply@cohichat.com");
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 이메일을 전송한다")
+    void sendPasswordResetEmail() {
+        // given
+        String to = "user@example.com";
+        String resetLink = "http://localhost:3000/password-reset/confirm?token=abc123";
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        emailService.sendPasswordResetEmail(to, resetLink);
+
+        // then
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+
+    @Test
+    @DisplayName("이메일 전송 실패 시 예외를 던지지 않고 로그만 남긴다")
+    void sendPasswordResetEmail_failure_logsError() {
+        // given
+        String to = "user@example.com";
+        String resetLink = "http://localhost:3000/password-reset/confirm?token=abc123";
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doThrow(new RuntimeException("SMTP error")).when(mailSender).send(any(MimeMessage.class));
+
+        // when & then - should not throw
+        emailService.sendPasswordResetEmail(to, resetLink);
+    }
+}

--- a/backend/src/test/java/com/coDevs/cohiChat/member/PasswordResetControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/member/PasswordResetControllerTest.java
@@ -1,0 +1,138 @@
+package com.coDevs.cohiChat.member;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.coDevs.cohiChat.global.exception.CustomException;
+import com.coDevs.cohiChat.global.exception.ErrorCode;
+import com.coDevs.cohiChat.global.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(PasswordResetController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class PasswordResetControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PasswordResetService passwordResetService;
+
+    @Nested
+    @DisplayName("POST /members/v1/password-reset/request")
+    class RequestPasswordReset {
+
+        @Test
+        @DisplayName("성공: 비밀번호 재설정 요청")
+        void requestPasswordReset_success() throws Exception {
+            // given
+            String email = "user@example.com";
+            doNothing().when(passwordResetService).requestPasswordReset(email);
+
+            // when & then
+            mockMvc.perform(post("/members/v1/password-reset/request")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"email\": \"" + email + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("비밀번호 재설정 이메일이 발송되었습니다."));
+
+            verify(passwordResetService).requestPasswordReset(email);
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 이메일 형식")
+        void requestPasswordReset_invalidEmail() throws Exception {
+            mockMvc.perform(post("/members/v1/password-reset/request")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"email\": \"invalid-email\"}"))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 이메일 누락")
+        void requestPasswordReset_missingEmail() throws Exception {
+            mockMvc.perform(post("/members/v1/password-reset/request")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+                .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /members/v1/password-reset/confirm")
+    class ConfirmPasswordReset {
+
+        @Test
+        @DisplayName("성공: 비밀번호 재설정 완료")
+        void confirmPasswordReset_success() throws Exception {
+            // given
+            String token = "valid-token";
+            String newPassword = "newPassword123!";
+            doNothing().when(passwordResetService).resetPassword(token, newPassword);
+
+            // when & then
+            mockMvc.perform(post("/members/v1/password-reset/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"token\": \"" + token + "\", \"newPassword\": \"" + newPassword + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("비밀번호가 성공적으로 변경되었습니다."));
+
+            verify(passwordResetService).resetPassword(token, newPassword);
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 토큰")
+        void confirmPasswordReset_invalidToken() throws Exception {
+            // given
+            String token = "invalid-token";
+            String newPassword = "newPassword123!";
+            doThrow(new CustomException(ErrorCode.INVALID_RESET_TOKEN))
+                .when(passwordResetService).resetPassword(token, newPassword);
+
+            // when & then
+            mockMvc.perform(post("/members/v1/password-reset/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"token\": \"" + token + "\", \"newPassword\": \"" + newPassword + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.message").value(ErrorCode.INVALID_RESET_TOKEN.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패: 비밀번호 형식 오류")
+        void confirmPasswordReset_invalidPassword() throws Exception {
+            mockMvc.perform(post("/members/v1/password-reset/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"token\": \"valid-token\", \"newPassword\": \"short\"}"))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 토큰 누락")
+        void confirmPasswordReset_missingToken() throws Exception {
+            mockMvc.perform(post("/members/v1/password-reset/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"newPassword\": \"newPassword123!\"}"))
+                .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/backend/src/test/java/com/coDevs/cohiChat/member/PasswordResetServiceTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/member/PasswordResetServiceTest.java
@@ -1,0 +1,199 @@
+package com.coDevs.cohiChat.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.coDevs.cohiChat.email.EmailService;
+import com.coDevs.cohiChat.global.exception.CustomException;
+import com.coDevs.cohiChat.global.exception.ErrorCode;
+import com.coDevs.cohiChat.member.entity.Member;
+import com.coDevs.cohiChat.member.entity.PasswordResetToken;
+import com.coDevs.cohiChat.member.entity.Role;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private EmailService emailService;
+
+    private PasswordResetService passwordResetService;
+
+    private static final String BASE_URL = "http://localhost:3000";
+    private static final long TOKEN_EXPIRATION_MINUTES = 30;
+
+    @BeforeEach
+    void setUp() {
+        passwordResetService = new PasswordResetService(
+            memberRepository,
+            passwordResetTokenRepository,
+            passwordEncoder,
+            emailService,
+            BASE_URL,
+            TOKEN_EXPIRATION_MINUTES
+        );
+    }
+
+    @Nested
+    @DisplayName("비밀번호 재설정 요청")
+    class RequestPasswordReset {
+
+        @Test
+        @DisplayName("성공: 존재하는 이메일로 재설정 요청 시 토큰 생성 및 이메일 발송")
+        void requestPasswordReset_success() {
+            // given
+            String email = "user@example.com";
+            Member member = createMember(email);
+            when(memberRepository.findByEmailAndIsDeletedFalse(email)).thenReturn(Optional.of(member));
+            when(passwordResetTokenRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+            // when
+            passwordResetService.requestPasswordReset(email);
+
+            // then
+            ArgumentCaptor<PasswordResetToken> tokenCaptor = ArgumentCaptor.forClass(PasswordResetToken.class);
+            verify(passwordResetTokenRepository).save(tokenCaptor.capture());
+
+            PasswordResetToken savedToken = tokenCaptor.getValue();
+            assertThat(savedToken.getEmail()).isEqualTo(email);
+            assertThat(savedToken.getToken()).isNotBlank();
+
+            verify(emailService).sendPasswordResetEmail(
+                eq(email),
+                contains(savedToken.getToken())
+            );
+        }
+
+        @Test
+        @DisplayName("성공: 존재하지 않는 이메일로 요청해도 예외 없이 조용히 종료 (보안)")
+        void requestPasswordReset_emailNotFound_silentlyIgnore() {
+            // given
+            String email = "nonexistent@example.com";
+            when(memberRepository.findByEmailAndIsDeletedFalse(email)).thenReturn(Optional.empty());
+
+            // when & then - should not throw
+            passwordResetService.requestPasswordReset(email);
+
+            verify(passwordResetTokenRepository, never()).save(any());
+            verify(emailService, never()).sendPasswordResetEmail(any(), any());
+        }
+
+        @Test
+        @DisplayName("성공: 기존 토큰이 있으면 삭제 후 새 토큰 생성")
+        void requestPasswordReset_existingToken_replacesOldToken() {
+            // given
+            String email = "user@example.com";
+            Member member = createMember(email);
+            PasswordResetToken existingToken = PasswordResetToken.create("old-token", email, 1800000L);
+
+            when(memberRepository.findByEmailAndIsDeletedFalse(email)).thenReturn(Optional.of(member));
+            when(passwordResetTokenRepository.findByEmail(email)).thenReturn(Optional.of(existingToken));
+
+            // when
+            passwordResetService.requestPasswordReset(email);
+
+            // then
+            verify(passwordResetTokenRepository).deleteById("old-token");
+            verify(passwordResetTokenRepository).save(any(PasswordResetToken.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 재설정 확인")
+    class ResetPassword {
+
+        @Test
+        @DisplayName("성공: 유효한 토큰으로 비밀번호 변경")
+        void resetPassword_success() {
+            // given
+            String token = UUID.randomUUID().toString();
+            String email = "user@example.com";
+            String newPassword = "newPassword123!";
+            String encodedPassword = "encoded_password";
+
+            PasswordResetToken resetToken = PasswordResetToken.create(token, email, 1800000L);
+            Member member = createMember(email);
+
+            when(passwordResetTokenRepository.findById(token)).thenReturn(Optional.of(resetToken));
+            when(memberRepository.findByEmailAndIsDeletedFalse(email)).thenReturn(Optional.of(member));
+            when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
+
+            // when
+            passwordResetService.resetPassword(token, newPassword);
+
+            // then
+            verify(passwordEncoder).encode(newPassword);
+            verify(passwordResetTokenRepository).deleteById(token);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 토큰으로 요청")
+        void resetPassword_invalidToken_throwsException() {
+            // given
+            String token = "invalid-token";
+            String newPassword = "newPassword123!";
+
+            when(passwordResetTokenRepository.findById(token)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> passwordResetService.resetPassword(token, newPassword))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_RESET_TOKEN);
+        }
+
+        @Test
+        @DisplayName("실패: 토큰에 연결된 사용자가 없음")
+        void resetPassword_userNotFound_throwsException() {
+            // given
+            String token = UUID.randomUUID().toString();
+            String email = "deleted@example.com";
+            String newPassword = "newPassword123!";
+
+            PasswordResetToken resetToken = PasswordResetToken.create(token, email, 1800000L);
+
+            when(passwordResetTokenRepository.findById(token)).thenReturn(Optional.of(resetToken));
+            when(memberRepository.findByEmailAndIsDeletedFalse(email)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> passwordResetService.resetPassword(token, newPassword))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    private Member createMember(String email) {
+        return Member.create(
+            "testuser",
+            "Test User",
+            email,
+            "hashedPassword",
+            Role.GUEST
+        );
+    }
+}

--- a/backend/src/test/java/com/coDevs/cohiChat/member/PasswordResetTokenRepositoryTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/member/PasswordResetTokenRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.coDevs.cohiChat.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.coDevs.cohiChat.config.EmbeddedRedisConfig;
+import com.coDevs.cohiChat.member.entity.PasswordResetToken;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(EmbeddedRedisConfig.class)
+class PasswordResetTokenRepositoryTest {
+
+    @Autowired
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    private final String testToken = "test-reset-token-uuid";
+    private final String testEmail = "user@example.com";
+
+    @BeforeEach
+    void setUp() {
+        PasswordResetToken token = PasswordResetToken.create(
+            testToken,
+            testEmail,
+            1800000L // 30 minutes
+        );
+        passwordResetTokenRepository.save(token);
+    }
+
+    @AfterEach
+    void tearDown() {
+        passwordResetTokenRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("성공: PasswordResetToken 저장 및 토큰으로 조회")
+    void saveAndFindByToken() {
+        // when
+        Optional<PasswordResetToken> found = passwordResetTokenRepository.findById(testToken);
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getToken()).isEqualTo(testToken);
+        assertThat(found.get().getEmail()).isEqualTo(testEmail);
+    }
+
+    @Test
+    @DisplayName("성공: 이메일로 토큰 조회")
+    void findByEmail() {
+        // when
+        Optional<PasswordResetToken> found = passwordResetTokenRepository.findByEmail(testEmail);
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getToken()).isEqualTo(testToken);
+    }
+
+    @Test
+    @DisplayName("성공: 존재하지 않는 토큰 조회 시 빈 Optional 반환")
+    void findByTokenNotFound() {
+        // when
+        Optional<PasswordResetToken> found = passwordResetTokenRepository.findById("non-existent-token");
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("성공: 토큰 삭제")
+    void deleteByToken() {
+        // when
+        passwordResetTokenRepository.deleteById(testToken);
+
+        // then
+        Optional<PasswordResetToken> found = passwordResetTokenRepository.findById(testToken);
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("성공: 이메일로 조회 후 토큰 삭제")
+    void deleteByEmailUsingFindAndDelete() {
+        // given
+        Optional<PasswordResetToken> found = passwordResetTokenRepository.findByEmail(testEmail);
+        assertThat(found).isPresent();
+
+        // when - email로 찾은 후 token ID로 삭제
+        passwordResetTokenRepository.deleteById(found.get().getToken());
+
+        // then
+        Optional<PasswordResetToken> afterDelete = passwordResetTokenRepository.findByEmail(testEmail);
+        assertThat(afterDelete).isEmpty();
+    }
+}

--- a/frontend/src/features/member/api/memberApi.ts
+++ b/frontend/src/features/member/api/memberApi.ts
@@ -6,6 +6,9 @@ import type {
     SignupPayload,
     SignupResponse,
     MemberResponseDTO,
+    PasswordResetRequestPayload,
+    PasswordResetConfirmPayload,
+    PasswordResetResponse,
 } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080/api';
@@ -70,4 +73,40 @@ export async function getUserApi(username: string): Promise<MemberResponseDTO> {
     return httpClient<MemberResponseDTO>(
         `${MEMBER_API}/${encodeURIComponent(username)}`
     );
+}
+
+export async function requestPasswordResetApi(
+    payload: PasswordResetRequestPayload
+): Promise<PasswordResetResponse> {
+    const response = await httpClient<PasswordResetResponse>(
+        `${MEMBER_API}/password-reset/request`,
+        {
+            method: 'POST',
+            body: payload,
+        }
+    );
+
+    if (!response) {
+        throw new Error('서버로부터 응답을 받지 못했습니다.');
+    }
+
+    return response;
+}
+
+export async function confirmPasswordResetApi(
+    payload: PasswordResetConfirmPayload
+): Promise<PasswordResetResponse> {
+    const response = await httpClient<PasswordResetResponse>(
+        `${MEMBER_API}/password-reset/confirm`,
+        {
+            method: 'POST',
+            body: payload,
+        }
+    );
+
+    if (!response) {
+        throw new Error('서버로부터 응답을 받지 못했습니다.');
+    }
+
+    return response;
 }

--- a/frontend/src/features/member/components/LoginForm.tsx
+++ b/frontend/src/features/member/components/LoginForm.tsx
@@ -115,6 +115,12 @@ export function LoginForm() {
                         </div>
                     )}
 
+                    <div className="text-right">
+                        <Link to="/app/password-reset" className="text-sm text-[var(--cohe-primary)] hover:underline">
+                            비밀번호를 잊으셨나요?
+                        </Link>
+                    </div>
+
                     <button
                         type="submit"
                         disabled={isPending}

--- a/frontend/src/features/member/components/PasswordResetConfirmForm.tsx
+++ b/frontend/src/features/member/components/PasswordResetConfirmForm.tsx
@@ -1,0 +1,183 @@
+import { useState, useEffect } from 'react';
+import { Link, useSearch } from '@tanstack/react-router';
+import { usePasswordResetConfirm } from '../hooks/usePasswordReset';
+
+function CoffeeCupIcon({ className = '' }: { className?: string }) {
+    return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M2 21V19H20V21H2ZM4 18C3.45 18 2.979 17.804 2.587 17.412C2.195 17.02 1.99933 16.5493 2 16V5H18V9H20C20.55 9 21.021 9.196 21.413 9.588C21.805 9.98 22.0007 10.4507 22 11V14C22 14.55 21.804 15.021 21.412 15.413C21.02 15.805 20.5493 16.0007 20 16H18V18H4ZM18 14H20V11H18V14ZM4 16H16V7H4V16Z"/>
+            <path d="M7 4C7 3.5 7.5 2 9 2C10.5 2 11 3.5 11 4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round"/>
+        </svg>
+    );
+}
+
+const PASSWORD_REGEX = /^[a-zA-Z0-9!@#$%^&*._-]{8,20}$/;
+
+export function PasswordResetConfirmForm() {
+    const search = useSearch({ strict: false }) as { token?: string };
+    const token = search.token || '';
+
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [validationError, setValidationError] = useState('');
+    const [isSuccess, setIsSuccess] = useState(false);
+    const resetMutation = usePasswordResetConfirm();
+
+    useEffect(() => {
+        if (!token) {
+            setValidationError('유효하지 않은 링크입니다.');
+        }
+    }, [token]);
+
+    const validatePasswords = (): boolean => {
+        if (!PASSWORD_REGEX.test(newPassword)) {
+            setValidationError('비밀번호는 영문, 숫자, 특수문자(!@#$%^&*._-)를 포함한 8~20자여야 합니다.');
+            return false;
+        }
+        if (newPassword !== confirmPassword) {
+            setValidationError('비밀번호가 일치하지 않습니다.');
+            return false;
+        }
+        setValidationError('');
+        return true;
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!validatePasswords()) return;
+
+        resetMutation.mutate(
+            { token, newPassword },
+            {
+                onSuccess: () => setIsSuccess(true),
+            }
+        );
+    };
+
+    const isPending = resetMutation.isPending;
+
+    if (isSuccess) {
+        return (
+            <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--cohe-bg-warm)]">
+                <div className="flex items-center gap-2 mb-8">
+                    <CoffeeCupIcon className="w-10 h-10 text-[var(--cohe-primary)]" />
+                    <span className="text-2xl font-bold text-[var(--cohe-text-dark)]">coheChat</span>
+                </div>
+
+                <div className="w-full max-w-sm bg-white rounded-2xl shadow-lg p-8 text-center">
+                    <div className="w-16 h-16 mx-auto mb-4 bg-green-100 rounded-full flex items-center justify-center">
+                        <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                        </svg>
+                    </div>
+                    <h2 className="text-xl font-bold text-[var(--cohe-text-dark)] mb-4">비밀번호가 변경되었습니다</h2>
+                    <p className="text-gray-600 mb-6">
+                        새 비밀번호로 로그인해주세요.
+                    </p>
+                    <Link
+                        to="/app/login"
+                        className="inline-block w-full py-3 bg-[var(--cohe-primary)] text-white font-semibold rounded-lg hover:bg-[var(--cohe-primary-dark)] transition-colors"
+                    >
+                        로그인하기
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    if (!token) {
+        return (
+            <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--cohe-bg-warm)]">
+                <div className="flex items-center gap-2 mb-8">
+                    <CoffeeCupIcon className="w-10 h-10 text-[var(--cohe-primary)]" />
+                    <span className="text-2xl font-bold text-[var(--cohe-text-dark)]">coheChat</span>
+                </div>
+
+                <div className="w-full max-w-sm bg-white rounded-2xl shadow-lg p-8 text-center">
+                    <div className="w-16 h-16 mx-auto mb-4 bg-red-100 rounded-full flex items-center justify-center">
+                        <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </div>
+                    <h2 className="text-xl font-bold text-[var(--cohe-text-dark)] mb-4">유효하지 않은 링크</h2>
+                    <p className="text-gray-600 mb-6">
+                        비밀번호 재설정 링크가 유효하지 않거나 만료되었습니다.
+                        <br />
+                        다시 요청해주세요.
+                    </p>
+                    <Link
+                        to="/app/password-reset"
+                        className="inline-block w-full py-3 bg-[var(--cohe-primary)] text-white font-semibold rounded-lg hover:bg-[var(--cohe-primary-dark)] transition-colors"
+                    >
+                        다시 요청하기
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--cohe-bg-warm)]">
+            <div className="flex items-center gap-2 mb-8">
+                <CoffeeCupIcon className="w-10 h-10 text-[var(--cohe-primary)]" />
+                <span className="text-2xl font-bold text-[var(--cohe-text-dark)]">coheChat</span>
+            </div>
+
+            <div className="w-full max-w-sm bg-white rounded-2xl shadow-lg p-8">
+                <h2 className="text-2xl font-bold text-center text-[var(--cohe-text-dark)] mb-2">새 비밀번호 설정</h2>
+                <p className="text-center text-gray-500 text-sm mb-6">
+                    새로운 비밀번호를 입력해주세요.
+                </p>
+
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-1">
+                        <label htmlFor="newPassword" className="text-sm text-[var(--cohe-text-dark)]">새 비밀번호</label>
+                        <input
+                            type="password"
+                            id="newPassword"
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                            disabled={isPending}
+                            required
+                            placeholder="8~20자 영문, 숫자, 특수문자"
+                            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-[var(--cohe-primary)] transition-colors"
+                        />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <label htmlFor="confirmPassword" className="text-sm text-[var(--cohe-text-dark)]">비밀번호 확인</label>
+                        <input
+                            type="password"
+                            id="confirmPassword"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            disabled={isPending}
+                            required
+                            placeholder="비밀번호 재입력"
+                            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-[var(--cohe-primary)] transition-colors"
+                        />
+                    </div>
+
+                    {(validationError || resetMutation.isError) && (
+                        <div className="text-red-600 text-sm">
+                            {validationError || resetMutation.error?.message || '비밀번호 변경에 실패했습니다.'}
+                        </div>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="w-full py-3 bg-[var(--cohe-primary)] text-white font-semibold rounded-lg hover:bg-[var(--cohe-primary-dark)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-2"
+                    >
+                        {isPending ? '처리 중...' : '비밀번호 변경'}
+                    </button>
+                </form>
+
+                <div className="text-center text-sm mt-6 text-[var(--cohe-text-dark)]">
+                    <Link to="/app/login" className="text-[var(--cohe-primary)] font-semibold hover:underline">
+                        로그인으로 돌아가기
+                    </Link>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/member/components/PasswordResetRequestForm.tsx
+++ b/frontend/src/features/member/components/PasswordResetRequestForm.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { usePasswordResetRequest } from '../hooks/usePasswordReset';
+
+function CoffeeCupIcon({ className = '' }: { className?: string }) {
+    return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M2 21V19H20V21H2ZM4 18C3.45 18 2.979 17.804 2.587 17.412C2.195 17.02 1.99933 16.5493 2 16V5H18V9H20C20.55 9 21.021 9.196 21.413 9.588C21.805 9.98 22.0007 10.4507 22 11V14C22 14.55 21.804 15.021 21.412 15.413C21.02 15.805 20.5493 16.0007 20 16H18V18H4ZM18 14H20V11H18V14ZM4 16H16V7H4V16Z"/>
+            <path d="M7 4C7 3.5 7.5 2 9 2C10.5 2 11 3.5 11 4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round"/>
+        </svg>
+    );
+}
+
+export function PasswordResetRequestForm() {
+    const [email, setEmail] = useState('');
+    const [isSubmitted, setIsSubmitted] = useState(false);
+    const resetMutation = usePasswordResetRequest();
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        resetMutation.mutate(
+            { email: email.trim().toLowerCase() },
+            {
+                onSuccess: () => setIsSubmitted(true),
+            }
+        );
+    };
+
+    const isPending = resetMutation.isPending;
+
+    if (isSubmitted) {
+        return (
+            <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--cohe-bg-warm)]">
+                <div className="flex items-center gap-2 mb-8">
+                    <CoffeeCupIcon className="w-10 h-10 text-[var(--cohe-primary)]" />
+                    <span className="text-2xl font-bold text-[var(--cohe-text-dark)]">coheChat</span>
+                </div>
+
+                <div className="w-full max-w-sm bg-white rounded-2xl shadow-lg p-8 text-center">
+                    <div className="w-16 h-16 mx-auto mb-4 bg-green-100 rounded-full flex items-center justify-center">
+                        <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                        </svg>
+                    </div>
+                    <h2 className="text-xl font-bold text-[var(--cohe-text-dark)] mb-4">이메일을 확인해주세요</h2>
+                    <p className="text-gray-600 mb-6">
+                        입력하신 이메일 주소로 비밀번호 재설정 링크를 발송했습니다.
+                        <br />
+                        <span className="text-sm text-gray-500">(이메일이 등록되어 있는 경우에만 발송됩니다)</span>
+                    </p>
+                    <Link
+                        to="/app/login"
+                        className="inline-block w-full py-3 bg-[var(--cohe-primary)] text-white font-semibold rounded-lg hover:bg-[var(--cohe-primary-dark)] transition-colors"
+                    >
+                        로그인으로 돌아가기
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--cohe-bg-warm)]">
+            <div className="flex items-center gap-2 mb-8">
+                <CoffeeCupIcon className="w-10 h-10 text-[var(--cohe-primary)]" />
+                <span className="text-2xl font-bold text-[var(--cohe-text-dark)]">coheChat</span>
+            </div>
+
+            <div className="w-full max-w-sm bg-white rounded-2xl shadow-lg p-8">
+                <h2 className="text-2xl font-bold text-center text-[var(--cohe-text-dark)] mb-2">비밀번호 재설정</h2>
+                <p className="text-center text-gray-500 text-sm mb-6">
+                    가입하신 이메일 주소를 입력해주세요.
+                    <br />
+                    비밀번호 재설정 링크를 보내드립니다.
+                </p>
+
+                <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-1">
+                        <label htmlFor="email" className="text-sm text-[var(--cohe-text-dark)]">이메일</label>
+                        <input
+                            type="email"
+                            id="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            disabled={isPending}
+                            required
+                            placeholder="example@email.com"
+                            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-[var(--cohe-primary)] transition-colors"
+                        />
+                    </div>
+
+                    {resetMutation.isError && (
+                        <div className="text-red-600 text-sm">
+                            {resetMutation.error?.message || '요청에 실패했습니다. 다시 시도해주세요.'}
+                        </div>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="w-full py-3 bg-[var(--cohe-primary)] text-white font-semibold rounded-lg hover:bg-[var(--cohe-primary-dark)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-2"
+                    >
+                        {isPending ? '처리 중...' : '재설정 링크 받기'}
+                    </button>
+                </form>
+
+                <div className="text-center text-sm mt-6 text-[var(--cohe-text-dark)]">
+                    <Link to="/app/login" className="text-[var(--cohe-primary)] font-semibold hover:underline">
+                        로그인으로 돌아가기
+                    </Link>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/member/hooks/usePasswordReset.ts
+++ b/frontend/src/features/member/hooks/usePasswordReset.ts
@@ -1,0 +1,36 @@
+import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import {
+    requestPasswordResetApi,
+    confirmPasswordResetApi,
+} from '../api/memberApi';
+import type {
+    PasswordResetRequestPayload,
+    PasswordResetConfirmPayload,
+    PasswordResetResponse,
+} from '../types';
+
+export function usePasswordResetRequest(): UseMutationResult<
+    PasswordResetResponse,
+    Error,
+    PasswordResetRequestPayload
+    > {
+    return useMutation<PasswordResetResponse, Error, PasswordResetRequestPayload>({
+        mutationFn: requestPasswordResetApi,
+        onError: (error) => {
+            console.error('Password reset request error:', error);
+        },
+    });
+}
+
+export function usePasswordResetConfirm(): UseMutationResult<
+    PasswordResetResponse,
+    Error,
+    PasswordResetConfirmPayload
+    > {
+    return useMutation<PasswordResetResponse, Error, PasswordResetConfirmPayload>({
+        mutationFn: confirmPasswordResetApi,
+        onError: (error) => {
+            console.error('Password reset confirm error:', error);
+        },
+    });
+}

--- a/frontend/src/features/member/index.ts
+++ b/frontend/src/features/member/index.ts
@@ -3,10 +3,16 @@ export { useAuth } from './hooks/useAuth';
 export { useLogin } from './hooks/useLogin';
 export { useLogout } from './hooks/useLogout';
 export { useSignup } from './hooks/useSignup';
+export {
+    usePasswordResetRequest,
+    usePasswordResetConfirm,
+} from './hooks/usePasswordReset';
 
 // components
 export { LoginForm } from './components/LoginForm';
 export { SignupForm } from './components/SignupForm';
+export { PasswordResetRequestForm } from './components/PasswordResetRequestForm';
+export { PasswordResetConfirmForm } from './components/PasswordResetConfirmForm';
 
 // types
 export type {
@@ -21,4 +27,7 @@ export type {
     LoginResponse,
     SignupPayload,
     SignupResponse,
+    PasswordResetRequestPayload,
+    PasswordResetConfirmPayload,
+    PasswordResetResponse,
 } from './types';

--- a/frontend/src/features/member/types/index.ts
+++ b/frontend/src/features/member/types/index.ts
@@ -59,3 +59,16 @@ export interface SignupResponse {
     username: string;
     displayName: string;
 }
+
+export interface PasswordResetRequestPayload {
+    email: string;
+}
+
+export interface PasswordResetConfirmPayload {
+    token: string;
+    newPassword: string;
+}
+
+export interface PasswordResetResponse {
+    message: string;
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import {
     createRoute,
 } from '@tanstack/react-router'
 import Calendar from '../pages/calendar/Calendar'
-import { LoginForm, SignupForm } from '~/features/member'
+import { LoginForm, SignupForm, PasswordResetRequestForm, PasswordResetConfirmForm } from '~/features/member'
 import Home from '~/pages/main/Home'
 import MyBookings from '~/pages/calendar/MyBookings'
 import Booking from '~/pages/calendar/Booking'
@@ -80,6 +80,21 @@ const signupRoute = createRoute({
     component: SignupForm,
 })
 
+const passwordResetRoute = createRoute({
+    getParentRoute: () => RootRoute,
+    path: '/app/password-reset',
+    component: PasswordResetRequestForm,
+})
+
+const passwordResetConfirmRoute = createRoute({
+    getParentRoute: () => RootRoute,
+    path: '/app/password-reset/confirm',
+    component: PasswordResetConfirmForm,
+    validateSearch: z.object({
+        token: z.string().optional(),
+    }),
+})
+
 
 const hostRegisterRoute = createRoute({
     getParentRoute: () => RootRoute,
@@ -124,6 +139,8 @@ export const routeTree = RootRoute.addChildren([
     calendarRoute,
     loginRoute,
     signupRoute,
+    passwordResetRoute,
+    passwordResetConfirmRoute,
     myBookingsRoute,
     bookingRoute,
     hostRegisterRoute,


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #226

---

## 📦 뭘 만들었나요? (What)

이메일을 통한 비밀번호 재설정 기능을 구현했습니다.

### Backend
- `EmailService`: SMTP를 통한 이메일 발송 서비스
- `PasswordResetToken`: Redis 기반 토큰 관리 (30분 TTL)
- `PasswordResetService`: 재설정 요청/확인 비즈니스 로직
- `PasswordResetController`: API 엔드포인트
  - `POST /api/members/v1/password-reset/request`
  - `POST /api/members/v1/password-reset/confirm`

### Frontend
- `/app/password-reset`: 이메일 입력 페이지
- `/app/password-reset/confirm?token=...`: 새 비밀번호 설정 페이지
- 로그인 폼에 "비밀번호를 잊으셨나요?" 링크 추가

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. **토큰 저장소**: DB vs Redis
   - Redis 선택: 기존 RefreshToken과 동일한 패턴 유지, TTL 자동 만료 활용

2. **보안 고려사항**:
   - 이메일 존재 여부 미노출 (항상 "이메일 발송됨" 응답)
   - 토큰 사용 후 즉시 삭제
   - 30분 만료 시간 설정

3. **서비스 분리**: `MemberService` vs 별도 서비스
   - `PasswordResetService`로 분리: 단일 책임 원칙, 코드 복잡도 관리

---

## 어떻게 테스트했나요? (Test)

- 단위 테스트 작성 (Backend)
  - `EmailServiceTest`
  - `PasswordResetTokenRepositoryTest`
  - `PasswordResetServiceTest`
  - `PasswordResetControllerTest`
- 프론트엔드 빌드 및 린트 검증

<details>
<summary>테스트 시나리오</summary>

1. 존재하는 이메일로 재설정 요청 → 토큰 생성, 이메일 발송
2. 존재하지 않는 이메일로 요청 → 예외 없이 동일 응답 (보안)
3. 유효한 토큰으로 비밀번호 변경 → 성공, 토큰 삭제
4. 잘못된 토큰으로 비밀번호 변경 → INVALID_RESET_TOKEN 에러

</details>

---

## 참고사항 / 회고 메모 (Notes)

### 환경변수 설정 필요
SMTP 이메일 발송을 위해 다음 환경변수 설정이 필요합니다:
```
MAIL_USERNAME=your-email@gmail.com
MAIL_PASSWORD=your-app-password
```

Gmail 사용 시 [앱 비밀번호](https://support.google.com/accounts/answer/185833)를 생성하여 사용해야 합니다.