### PR TITLE
fix: #236 타임슬롯 설정 UX 개선 (인라인 검증 + 미리보기 범위)

### DIFF
--- a/frontend/src/features/host/components/timeslot/TimeSlotForm.test.tsx
+++ b/frontend/src/features/host/components/timeslot/TimeSlotForm.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import TimeSlotForm, { type TimeSlotEntry } from './TimeSlotForm';
+
+describe('TimeSlotForm', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    const defaultProps = {
+        entries: [{ weekdays: [1, 2, 3, 4, 5], startTime: '09:00', endTime: '18:00' }] as TimeSlotEntry[],
+        onChange: vi.fn(),
+        onSave: vi.fn(),
+        isPending: false,
+        errors: {},
+    };
+
+    describe('인라인 시간 검증', () => {
+        it('시작 시간이 종료 시간보다 크거나 같으면 인라인 경고를 표시해야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1, 2, 3, 4, 5], startTime: '18:00', endTime: '09:00' },
+            ];
+
+            const { container } = render(
+                <TimeSlotForm {...defaultProps} entries={entries} />
+            );
+
+            const warningText = container.textContent;
+            expect(warningText).toContain('시작 시간은 종료 시간보다 이전이어야 합니다');
+        });
+
+        it('시작 시간과 종료 시간이 같으면 인라인 경고를 표시해야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1, 2, 3, 4, 5], startTime: '09:00', endTime: '09:00' },
+            ];
+
+            const { container } = render(
+                <TimeSlotForm {...defaultProps} entries={entries} />
+            );
+
+            const warningText = container.textContent;
+            expect(warningText).toContain('시작 시간은 종료 시간보다 이전이어야 합니다');
+        });
+
+        it('유효한 시간 범위에서는 인라인 경고를 표시하지 않아야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1, 2, 3, 4, 5], startTime: '09:00', endTime: '18:00' },
+            ];
+
+            const { container } = render(
+                <TimeSlotForm {...defaultProps} entries={entries} />
+            );
+
+            const warningText = container.textContent;
+            expect(warningText).not.toContain('시작 시간은 종료 시간보다 이전이어야 합니다');
+        });
+
+        it('여러 entry 중 일부만 유효하지 않으면 해당 entry에만 경고를 표시해야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1, 2, 3, 4, 5], startTime: '09:00', endTime: '18:00' },
+                { weekdays: [1, 2, 3, 4, 5], startTime: '20:00', endTime: '10:00' },
+            ];
+
+            const { container } = render(
+                <TimeSlotForm {...defaultProps} entries={entries} />
+            );
+
+            // 첫 번째 entry는 유효하므로 에러가 없어야 함
+            let warnings = container.querySelectorAll('[data-testid="time-validation-error"]');
+            expect(warnings.length).toBe(0);
+
+            // 두 번째 entry를 펼침
+            const entryHeaders = container.querySelectorAll('.cursor-pointer');
+            fireEvent.click(entryHeaders[1]);
+
+            // 두 번째 entry에 에러가 있어야 함
+            warnings = container.querySelectorAll('[data-testid="time-validation-error"]');
+            expect(warnings.length).toBe(1);
+        });
+    });
+});

--- a/frontend/src/features/host/components/timeslot/TimeSlotForm.tsx
+++ b/frontend/src/features/host/components/timeslot/TimeSlotForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 
 export interface TimeSlotEntry {
     weekdays: number[];
@@ -6,6 +6,10 @@ export interface TimeSlotEntry {
     endTime: string;
     /** 서버에서 불러온 기존 타임슬롯의 ID. undefined면 신규. */
     existingId?: number;
+}
+
+function isInvalidTimeRange(startTime: string, endTime: string): boolean {
+    return startTime >= endTime;
 }
 
 interface TimeSlotFormProps {
@@ -37,6 +41,16 @@ const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
 
 export default function TimeSlotForm({ entries, onChange, onSave, onDelete, isPending, deletingId, errors }: TimeSlotFormProps) {
     const [expandedIndex, setExpandedIndex] = useState(0);
+
+    const timeValidationErrors = useMemo(() => {
+        return entries.map((entry) => {
+            if (entry.existingId != null) return null;
+            if (isInvalidTimeRange(entry.startTime, entry.endTime)) {
+                return '시작 시간은 종료 시간보다 이전이어야 합니다';
+            }
+            return null;
+        });
+    }, [entries]);
 
     const updateEntry = (index: number, patch: Partial<TimeSlotEntry>) => {
         const updated = entries.map((e, i) => (i === index ? { ...e, ...patch } : e));
@@ -168,6 +182,16 @@ export default function TimeSlotForm({ entries, onChange, onSave, onDelete, isPe
                                         </select>
                                     </div>
                                 </div>
+
+                                {/* Inline time validation error */}
+                                {timeValidationErrors[index] && (
+                                    <p
+                                        data-testid="time-validation-error"
+                                        className="text-sm text-red-500 mt-2"
+                                    >
+                                        {timeValidationErrors[index]}
+                                    </p>
+                                )}
                             </div>
                         )}
                     </div>

--- a/frontend/src/features/host/components/timeslot/WeeklySchedulePreview.test.tsx
+++ b/frontend/src/features/host/components/timeslot/WeeklySchedulePreview.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import WeeklySchedulePreview from './WeeklySchedulePreview';
+import type { TimeSlotEntry } from './TimeSlotForm';
+
+describe('WeeklySchedulePreview', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    describe('동적 HOURS 범위', () => {
+        it('entries가 비어있으면 기본 범위(08:00~22:00)를 표시해야 한다', () => {
+            const { container } = render(<WeeklySchedulePreview entries={[]} />);
+
+            const timeLabels = container.querySelectorAll('.text-xs.text-gray-400');
+            const times = Array.from(timeLabels).map((el) => el.textContent);
+
+            expect(times).toContain('08:00');
+            expect(times).toContain('22:00');
+            expect(times).not.toContain('06:00');
+            expect(times).not.toContain('23:00');
+        });
+
+        it('08:00 이전 시간대를 포함하면 해당 시간대도 표시해야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1, 2, 3, 4, 5], startTime: '06:00', endTime: '10:00' },
+            ];
+
+            const { container } = render(<WeeklySchedulePreview entries={entries} />);
+
+            const timeLabels = container.querySelectorAll('.text-xs.text-gray-400');
+            const times = Array.from(timeLabels).map((el) => el.textContent);
+
+            expect(times).toContain('06:00');
+        });
+
+        it('22:00 이후 시간대를 포함하면 해당 시간대도 표시해야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1, 2, 3, 4, 5], startTime: '20:00', endTime: '23:30' },
+            ];
+
+            const { container } = render(<WeeklySchedulePreview entries={entries} />);
+
+            const timeLabels = container.querySelectorAll('.text-xs.text-gray-400');
+            const times = Array.from(timeLabels).map((el) => el.textContent);
+
+            expect(times).toContain('23:00');
+        });
+
+        it('여러 entry가 있을 때 전체 범위를 커버해야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1], startTime: '05:00', endTime: '08:00' },
+                { weekdays: [2], startTime: '20:00', endTime: '23:00' },
+            ];
+
+            const { container } = render(<WeeklySchedulePreview entries={entries} />);
+
+            const timeLabels = container.querySelectorAll('.text-xs.text-gray-400');
+            const times = Array.from(timeLabels).map((el) => el.textContent);
+
+            expect(times).toContain('05:00');
+            expect(times).toContain('23:00');
+        });
+
+        it('유효하지 않은 시간 범위(startTime >= endTime)는 미리보기에 반영하지 않아야 한다', () => {
+            const entries: TimeSlotEntry[] = [
+                { weekdays: [1, 2, 3, 4, 5], startTime: '18:00', endTime: '09:00' },
+            ];
+
+            const { container } = render(<WeeklySchedulePreview entries={entries} />);
+
+            // 하이라이트가 없어야 함 (유효하지 않은 범위이므로)
+            const highlightedCells = container.querySelectorAll('[style*="background-color"]');
+            expect(highlightedCells.length).toBe(0);
+        });
+    });
+});

--- a/frontend/src/features/host/components/timeslot/WeeklySchedulePreview.tsx
+++ b/frontend/src/features/host/components/timeslot/WeeklySchedulePreview.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { TimeSlotEntry } from './TimeSlotForm';
 
 interface WeeklySchedulePreviewProps {
@@ -6,20 +7,51 @@ interface WeeklySchedulePreviewProps {
 
 const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'];
 const DAY_MAP: Record<number, number> = { 1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 0: 6 }; // weekday(0=일) → column index
-const HOURS = Array.from({ length: 15 }, (_, i) => i + 8); // 08:00 ~ 22:00
 
-function timeToRow(time: string): number {
+const DEFAULT_START_HOUR = 8;
+const DEFAULT_END_HOUR = 22;
+
+function parseHour(time: string): number {
+    return parseInt(time.split(':')[0], 10);
+}
+
+function computeHoursRange(entries: TimeSlotEntry[]): number[] {
+    let minHour = DEFAULT_START_HOUR;
+    let maxHour = DEFAULT_END_HOUR;
+
+    for (const entry of entries) {
+        if (!entry.startTime || !entry.endTime || entry.weekdays.length === 0) continue;
+        const startHour = parseHour(entry.startTime);
+        const endHour = parseHour(entry.endTime);
+        // 유효하지 않은 범위는 무시
+        if (entry.startTime >= entry.endTime) continue;
+
+        minHour = Math.min(minHour, startHour);
+        // endTime의 시간이 분이 있으면 해당 시간대도 표시해야 함
+        const endMinute = parseInt(entry.endTime.split(':')[1], 10);
+        const adjustedEndHour = endMinute > 0 ? endHour + 1 : endHour;
+        maxHour = Math.max(maxHour, adjustedEndHour);
+    }
+
+    const length = maxHour - minHour + 1;
+    return Array.from({ length }, (_, i) => minHour + i);
+}
+
+function timeToRow(time: string, startHour: number): number {
     const [h, m] = time.split(':').map(Number);
-    return Math.max(0, (h - 8) * 2 + Math.round(m / 30));
+    return Math.max(0, (h - startHour) * 2 + Math.round(m / 30));
 }
 
 export default function WeeklySchedulePreview({ entries }: WeeklySchedulePreviewProps) {
+    const hours = useMemo(() => computeHoursRange(entries), [entries]);
+    const startHour = hours[0] ?? DEFAULT_START_HOUR;
+
     // Build highlight map: column → [startRow, endRow][]
     const highlights: Map<number, { start: number; end: number }[]> = new Map();
     for (const entry of entries) {
         if (!entry.startTime || !entry.endTime || entry.weekdays.length === 0) continue;
-        const startRow = timeToRow(entry.startTime);
-        const endRow = timeToRow(entry.endTime);
+        const startRow = timeToRow(entry.startTime, startHour);
+        const endRow = timeToRow(entry.endTime, startHour);
         if (startRow >= endRow) continue;
 
         for (const wd of entry.weekdays) {
@@ -49,7 +81,7 @@ export default function WeeklySchedulePreview({ entries }: WeeklySchedulePreview
                     {/* Grid */}
                     <div className="relative grid grid-cols-[50px_repeat(7,1fr)] gap-px bg-gray-100 rounded-lg overflow-hidden">
                         {/* Time labels + cells */}
-                        {HOURS.map((hour) => (
+                        {hours.map((hour) => (
                             <div key={hour} className="contents">
                                 {/* Time label */}
                                 <div className="bg-white flex items-start justify-end pr-2 pt-0.5 h-12">
@@ -59,7 +91,7 @@ export default function WeeklySchedulePreview({ entries }: WeeklySchedulePreview
                                 </div>
                                 {/* Day cells */}
                                 {Array.from({ length: 7 }, (_, colIdx) => {
-                                    const rowIdx = (hour - 8) * 2;
+                                    const rowIdx = (hour - startHour) * 2;
                                     const colHighlights = highlights.get(colIdx) ?? [];
                                     const isTop = colHighlights.some((h) => rowIdx >= h.start && rowIdx < h.end);
                                     const isBottom = colHighlights.some((h) => rowIdx + 1 >= h.start && rowIdx + 1 < h.end);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #236

---

## 📦 뭘 만들었나요? (What)

타임슬롯 설정 화면의 두 가지 UX 버그를 수정했습니다:

1. **인라인 시간 검증**: 시작 시간 >= 종료 시간 선택 시 즉시 빨간색 경고 메시지 표시
2. **미리보기 동적 범위**: 08:00 이전/22:00 이후 시간대 선택 시 주간 미리보기에 해당 시간대도 표시

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- 인라인 검증은 `useMemo`를 사용하여 entries가 변경될 때만 재계산하도록 최적화
- 미리보기 범위는 entries에서 최소/최대 시간을 계산하되, 유효하지 않은 범위(startTime >= endTime)는 무시하여 잘못된 입력이 미리보기를 깨뜨리지 않도록 함
- 기존 코드의 고정 HOURS 배열 대신 동적으로 생성하여 확장성 확보

---

## 어떻게 테스트했나요? (Test)

Vitest 단위 테스트 작성 (총 9개 테스트 통과)

<details>
<summary>테스트 시나리오 (선택)</summary>

**TimeSlotForm 테스트 (4개)**
1. 시작 시간 > 종료 시간 선택 시 인라인 경고 표시
2. 시작 시간 = 종료 시간 선택 시 인라인 경고 표시
3. 유효한 시간 범위 시 경고 미표시
4. 여러 entry 중 일부만 유효하지 않으면 해당 entry에만 경고 표시

**WeeklySchedulePreview 테스트 (5개)**
1. entries 비어있으면 기본 범위(08:00~22:00) 표시
2. 06:00~10:00 설정 시 06:00부터 표시
3. 20:00~23:30 설정 시 23:00까지 표시
4. 여러 entry가 있을 때 전체 범위 커버
5. 유효하지 않은 범위는 미리보기에 미반영

</details>

---

## 참고사항 / 회고 메모 (Notes)

- TDD 방식으로 테스트 먼저 작성 후 구현
- 기존 타임슬롯(existingId != null)은 검증 대상에서 제외 (수정 불가이므로)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 타임슬롯 폼에 인라인 시간 유효성 검사 추가: 시작 시간이 종료 시간보다 이전이어야 한다는 검증 오류 메시지 표시
- 주간 일정 미리보기의 시간 범위를 동적으로 계산: 입력된 시간대에 따라 표시되는 시간 범위가 자동으로 조정됨

## 테스트
- TimeSlotForm 및 WeeklySchedulePreview 컴포넌트의 새로운 테스트 스위트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->