### PR TITLE
fix: #256 캘린더 페이지 호스트 이름 displayName으로 표시

### DIFF
--- a/frontend/src/pages/calendar/Calendar.test.tsx
+++ b/frontend/src/pages/calendar/Calendar.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Mock TanStack Router
+vi.mock('@tanstack/react-router', () => ({
+    Link: ({ children, to, className }: { children: React.ReactNode; to: string; className?: string }) => (
+        <a href={to} className={className}>{children}</a>
+    ),
+    useSearch: () => ({ year: 2024, month: 1 }),
+    useParams: () => ({ slug: 'testuser' }),
+    useNavigate: () => vi.fn(),
+}));
+
+// Mock useHost hook
+vi.mock('~/hooks/useHost', () => ({
+    useHost: (username: string) => ({
+        data: username === 'testuser' ? { username: 'testuser', displayName: 'Test User Display' } : null,
+        isLoading: false,
+        isError: false,
+    }),
+    useHosts: () => ({
+        data: [{ username: 'testuser', displayName: 'Test User Display' }],
+        isLoading: false,
+    }),
+}));
+
+// Mock calendar features
+vi.mock('~/features/calendar', () => ({
+    Body: () => <div data-testid="calendar-body">Body</div>,
+    Navigator: () => <div data-testid="calendar-navigator">Navigator</div>,
+    Timeslots: () => <div data-testid="calendar-timeslots">Timeslots</div>,
+    BookingForm: () => <div data-testid="booking-form">BookingForm</div>,
+    getCalendarDays: () => [],
+    useCalendarEvent: () => ({ id: '1', name: 'Test Calendar' }),
+    useCalendarNavigation: () => ({ handlePrevious: vi.fn(), handleNext: vi.fn() }),
+    useTimeslots: () => ({ data: [] }),
+    useBookings: () => ({ data: [], refetch: vi.fn() }),
+    useBookingsStreamQuery: () => [],
+}));
+
+// Mock useAuth
+vi.mock('~/features/member', () => ({
+    useAuth: () => ({
+        isError: false,
+        isLoading: false,
+        data: { username: 'guest' },
+    }),
+}));
+
+import Calendar from './Calendar';
+
+describe('Calendar', () => {
+    let queryClient: QueryClient;
+
+    beforeEach(() => {
+        queryClient = new QueryClient({
+            defaultOptions: {
+                queries: { retry: false },
+            },
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('should display host displayName instead of username', () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Calendar />
+            </QueryClientProvider>
+        );
+
+        // displayName이 표시되어야 함
+        expect(screen.getByText('Test User Display')).toBeTruthy();
+        expect(screen.getByText(/님과 약속잡기/)).toBeTruthy();
+
+        // username이 직접 표시되면 안 됨 (displayName과 다른 경우)
+        const heading = screen.getByRole('heading', { level: 2 });
+        expect(heading.textContent).toContain('Test User Display');
+        expect(heading.textContent).not.toContain('testuser');
+    });
+});

--- a/frontend/src/pages/calendar/Calendar.tsx
+++ b/frontend/src/pages/calendar/Calendar.tsx
@@ -19,6 +19,7 @@ import type { ITimeSlot } from '~/features/calendar';
 
 import './calendar.less';
 import { useAuth } from '~/features/member';
+import { useHost } from '~/hooks/useHost';
 
 function Calendar({ baseDate }: { baseDate?: Date }) {
     const { year, month } = useSearch({ from: '/app/calendar/$slug' });
@@ -28,6 +29,7 @@ function Calendar({ baseDate }: { baseDate?: Date }) {
 
     const navigate = useNavigate();
     const auth = useAuth();
+    const { data: host } = useHost(slug);
     const calendar = useCalendarEvent(slug);
     const { data: timeslots = [] } = useTimeslots(slug);
     const { data: bookingsApi = [], refetch: refetchBookings } = useBookings(slug, selectedDate);
@@ -83,7 +85,7 @@ function Calendar({ baseDate }: { baseDate?: Date }) {
                     </div>
 
                     <h2 className="text-primary text-2xl">
-                        <span className="font-bold">{slug}</span>님과 약속잡기
+                        <span className="font-bold">{host?.displayName ?? slug}</span>님과 약속잡기
                     </h2>
                 </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #256

---

## 📦 뭘 만들었나요? (What)

캘린더 페이지에서 호스트 이름이 username으로 표시되던 버그를 수정했습니다.

**수정 전**: `/app/calendar/tare12` → "tare12님과 약속잡기"
**수정 후**: `/app/calendar/tare12` → "Tarte12님과 약속잡기"

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. 캘린더 페이지에서 호스트 정보를 조회할 방법:
   - **방법 A**: 새로운 API 엔드포인트 추가 (`GET /members/v1/hosts/{username}`)
   - **방법 B**: 기존 `useHosts()` 훅을 활용하여 필터링 (이미 `useHost(username)` 훅 존재)

   → 이미 `useHost(username)` 훅이 존재하므로 **방법 B** 선택. 추가 API 호출 없이 캐시된 호스트 목록에서 조회.

2. displayName이 없을 경우 처리:
   - `host?.displayName ?? slug` 형태로 fallback 처리하여 안전하게 표시

---

## 어떻게 테스트했나요? (Test)

- 단위 테스트 작성 (`Calendar.test.tsx`)
- 로컬에서 직접 실행하여 확인

<details>
<summary>테스트 시나리오</summary>

1. `/app` 페이지에서 호스트 목록 확인 (displayName 표시)
2. 호스트 클릭하여 캘린더 페이지 진입
3. 캘린더 페이지에서 동일한 displayName 표시 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- `useHost` 훅은 내부적으로 `useHosts()`를 호출하여 캐시된 데이터에서 필터링하므로 추가 네트워크 요청이 발생하지 않음
- 다른 페이지(MyBookings, Booking)는 이미 displayName을 올바르게 표시하고 있었음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캘린더 페이지에서 호스트명 표시 방식을 개선했습니다. 사용자 이름 대신 표시 이름이 정상적으로 나타나도록 수정되었습니다.

* **테스트**
  * 캘린더 페이지 컴포넌트에 대한 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->