### PR TITLE
fix: #257 예약 API topic 필드 검증 추가

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
@@ -57,6 +57,7 @@ public class BookingService {
         validateNotSelfBooking(guest, timeSlot);
         validateWeekdayAvailable(timeSlot, request.getBookingDate());
         validateNotDuplicateBooking(timeSlot, request.getBookingDate(), null);
+        validateTopic(timeSlot.getUserId(), request.getTopic());
 
         Booking booking = Booking.create(
             timeSlot,
@@ -140,6 +141,20 @@ public class BookingService {
         );
         if (exists) {
             throw new CustomException(ErrorCode.BOOKING_ALREADY_EXISTS);
+        }
+    }
+
+    /**
+     * 예약 주제(topic)가 호스트 캘린더에 정의된 topics 목록에 포함되는지 검증
+     * @param hostId 호스트 ID
+     * @param topic 검증할 주제
+     */
+    private void validateTopic(UUID hostId, String topic) {
+        Calendar calendar = calendarRepository.findById(hostId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CALENDAR_NOT_FOUND));
+
+        if (!calendar.getTopics().contains(topic)) {
+            throw new CustomException(ErrorCode.INVALID_TOPIC);
         }
     }
 
@@ -327,6 +342,7 @@ public class BookingService {
 
         validateWeekdayAvailable(newTimeSlot, request.getBookingDate());
         validateNotDuplicateBooking(newTimeSlot, request.getBookingDate(), bookingId);
+        validateTopic(newTimeSlot.getUserId(), request.getTopic());
 
         booking.update(request.getTopic(), request.getDescription(), newTimeSlot, request.getBookingDate());
 

--- a/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
 	BOOKING_NOT_CANCELLABLE(HttpStatus.UNPROCESSABLE_ENTITY, "취소할 수 없는 예약 상태입니다."),
 	BOOKING_NOT_MODIFIABLE(HttpStatus.UNPROCESSABLE_ENTITY, "상태를 변경할 수 없는 예약입니다."),
 	INVALID_BOOKING_STATUS(HttpStatus.UNPROCESSABLE_ENTITY, "유효하지 않은 예약 상태입니다."),
+	INVALID_TOPIC(HttpStatus.UNPROCESSABLE_ENTITY, "호스트가 정의한 상담 주제 중에서 선택해주세요."),
 
 	/**
 	 * 파일 관련 예외들.

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/BookingIntegrationTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/BookingIntegrationTest.java
@@ -78,10 +78,10 @@ class BookingIntegrationTest {
         );
         guest = memberRepository.save(guest);
 
-        // 호스트 캘린더 생성
+        // 호스트 캘린더 생성 (테스트에서 사용하는 모든 topic 포함)
         Calendar calendar = Calendar.create(
             host.getId(),
-            List.of("커리어 상담"),
+            List.of("커리어 상담", "프로젝트 상담", "첫 번째 상담", "두 번째 상담", "재예약 상담"),
             "게스트에게 보여줄 설명입니다.",
             "test@group.calendar.google.com"
         );


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #257

---

## 📦 뭘 만들었나요? (What)

예약 생성/수정 API에서 topic 필드 검증 기능 추가

- 게스트가 예약 생성/수정 시 호스트가 Calendar에 정의한 topics 목록에서만 선택 가능하도록 제한
- 정의되지 않은 topic 사용 시 `INVALID_TOPIC` 에러 반환

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

기존에는 게스트가 topic 필드에 임의의 값을 입력할 수 있어 데이터 무결성 문제가 발생했습니다.

- **방식 A**: DTO에서 topic 필드를 제거하고 서버에서만 관리
- **방식 B**: topic을 호스트의 Calendar.topics 목록과 비교하여 검증

방식 B를 선택한 이유:
- 호스트가 정의한 상담 주제 중에서 게스트가 선택하는 것이 비즈니스 요구사항에 부합
- 기존 API 스펙 변경 없이 검증 로직만 추가하여 하위 호환성 유지

---

## 어떻게 테스트했나요? (Test)

단위 테스트 및 통합 테스트 작성

<details>
<summary>테스트 시나리오</summary>

1. 유효한 topic으로 예약 생성 → 성공
2. 유효하지 않은 topic으로 예약 생성 → INVALID_TOPIC 예외
3. 호스트 캘린더가 없을 때 예약 생성 → CALENDAR_NOT_FOUND 예외
4. 유효한 topic으로 예약 수정 → 성공
5. 유효하지 않은 topic으로 예약 수정 → INVALID_TOPIC 예외

</details>

---

## 참고사항 / 회고 메모 (Notes)

- `validateTopic()` 메서드를 `createBooking()`, `updateBooking()` 양쪽에 추가
- 기존 테스트에서 Calendar mock 설정 보완
- 전체 355개 테스트 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 업데이트 사항

* **새 기능**
  * 예약 생성 및 수정 시 호스트의 상담 주제 목록에서만 주제를 선택할 수 있도록 검증 추가
  * 유효하지 않은 주제 선택 시 오류 메시지 표시

* **테스트**
  * 상담 주제 검증 관련 테스트 케이스 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->