### PR TITLE
fix: 호스트 등록 페이지에서  2, 3단계 카드 크기를 1, 4단계와 통일시킴

### DIFF
--- a/frontend/src/features/host/components/register/RegisterStep2.tsx
+++ b/frontend/src/features/host/components/register/RegisterStep2.tsx
@@ -119,7 +119,7 @@ export default function RegisterStep2({ data, onChange, errors }: RegisterStep2P
                     {/* Step 2 & 3 side by side */}
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         {/* Step 2 */}
-                        <div className="bg-[var(--cohe-bg-warm)]/50 rounded-2xl p-5">
+                        <div className="bg-[var(--cohe-bg-warm)]/50 rounded-2xl">
                             <div className="flex items-center gap-2 mb-3">
                                 <span className="w-7 h-7 rounded-full bg-[var(--cohe-primary)] text-white text-sm font-bold flex items-center justify-center">
                                     2
@@ -140,7 +140,7 @@ export default function RegisterStep2({ data, onChange, errors }: RegisterStep2P
                         </div>
 
                         {/* Step 3 */}
-                        <div className="bg-[var(--cohe-bg-warm)]/50 rounded-2xl p-5">
+                        <div className="bg-[var(--cohe-bg-warm)]/50 rounded-2xl">
                             <div className="flex items-center gap-2 mb-3">
                                 <span className="w-7 h-7 rounded-full bg-[var(--cohe-primary)] text-white text-sm font-bold flex items-center justify-center">
                                     3


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #260

---

## 📦 뭘 만들었나요? (What)

호스트 등록 2단계 페이지에서 Step 2("캘린더 설정 열기"), Step 3("캘린더 ID 복사") 카드의 `p-5` 패딩을 제거하여 Step 1 카드와 시각적 밸런스를 맞춤.

---

## 왜 이렇게 만들었나요? (Why)

Step 2/3 카드가 Step 1 카드와 Step 4 카드사이에 있는데, 서로 크기가 안 맞아 보여서 통일시킴

---

## 어떻게 테스트했나요? (Test)

모바일(390×844) 및 데스크톱 뷰포트에서 `/app/host/register` → 2단계 이동 후 Step 1, 2, 3 카드 패딩 일관성 확인

## 스크린샷

### Before

<img width="1788" height="1402" alt="스크린샷 2026-02-17 18 45 14" src="https://github.com/user-attachments/assets/b7ad0b99-b148-43d9-967f-ec93b0cbd67d" />

<img width="1788" height="1402" alt="스크린샷 2026-02-17 20 04 38" src="https://github.com/user-attachments/assets/c4c44ef4-b460-449f-a430-820017dac8f0" />


### After

<img width="1763" height="1401" alt="스크린샷 2026-02-17 19 22 58" src="https://github.com/user-attachments/assets/26f8cd0f-6a11-47d0-9410-1ef0fecb8c36" />

<img width="1763" height="1401" alt="스크린샷 2026-02-17 19 22 47" src="https://github.com/user-attachments/assets/abb22739-53fe-444b-86a9-80be6f5a93d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 등록 단계 화면의 카드 컨테이너 내부 패딩을 제거하여 시각적 간격을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->