### PR TITLE
refactor: #227 이메일 유효성 검증 로직 강화

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/member/request/SignupRequestDTO.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/request/SignupRequestDTO.java
@@ -27,7 +27,7 @@ public class SignupRequestDTO {
 	private String password;
 
 	@NotBlank(message = "이메일은 필수입니다.")
-	@Email
+	@Email(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "올바른 이메일 형식이 아닙니다.")
 	private String email;
 	
 	@Size(min = 2, max = 20)

--- a/backend/src/test/java/com/coDevs/cohiChat/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/member/MemberControllerTest.java
@@ -132,6 +132,20 @@ class MemberControllerTest {
 
 			performSignupTest(dto, shouldSucceed);
 		}
+
+		@ParameterizedTest
+		@MethodSource("com.coDevs.cohiChat.member.MemberControllerTest#emailTestProvider")
+		@DisplayName("이메일 검증 테스트")
+		void signupEmailTest(String email, boolean shouldSucceed) throws Exception {
+			SignupRequestDTO dto = SignupRequestDTO.builder()
+				.username(TEST_USERNAME)
+				.password(TEST_PASSWORD)
+				.email(email)
+				.displayName(TEST_DISPLAY_NAME)
+				.build();
+
+			performSignupTest(dto, shouldSucceed);
+		}
 	}
 
 	@Nested
@@ -320,6 +334,34 @@ class MemberControllerTest {
 			Arguments.of("aa", true),
 			Arguments.of("a".repeat(20), true),
 			Arguments.of("a".repeat(21), false)
+		);
+	}
+
+	static Stream<Arguments> emailTestProvider() {
+		return Stream.of(
+			// 유효한 이메일
+			Arguments.of("test@example.com", true),
+			Arguments.of("user.name@domain.co.kr", true),
+			Arguments.of("user+tag@example.org", true),
+			Arguments.of("user123@test.io", true),
+			Arguments.of("a.b.c@example.com", true),
+
+			// 무효한 이메일 - 형식 오류
+			Arguments.of(null, false),
+			Arguments.of("", false),
+			Arguments.of("test", false),
+			Arguments.of("test@", false),
+			Arguments.of("@test.com", false),
+			Arguments.of("test@.com", false),
+
+			// 무효한 이메일 - TLD 부족
+			Arguments.of("test@a", false),
+			Arguments.of("test@a.", false),
+			Arguments.of("a@b.c", false),
+
+			// 무효한 이메일 - 잘못된 문자
+			Arguments.of("test @example.com", false),
+			Arguments.of("test<>@example.com", false)
 		);
 	}
 

--- a/frontend/src/features/member/components/SignupForm.tsx
+++ b/frontend/src/features/member/components/SignupForm.tsx
@@ -7,7 +7,8 @@ import { useFormValidation, type ValidationRule } from '../hooks/useFormValidati
 // BE @Pattern과 동일한 검증 규칙
 const USERNAME_PATTERN = /^(?!hosts$)[a-zA-Z0-9._-]{4,12}$/i;
 const PASSWORD_PATTERN = /^[a-zA-Z0-9!@#$%^&*._-]{8,20}$/;
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// RFC 5322 기반 간소화 정규식: 로컬파트@도메인.TLD(2자이상)
+const EMAIL_PATTERN = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 interface SignupFormValues {
     username: string;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #227

---

## 📦 뭘 만들었나요? (What)

이메일 유효성 검증 로직을 RFC 5322 기반 정규식으로 강화했습니다.
- 백엔드: `@Email` 어노테이션에 regexp 속성 추가
- 프론트엔드: `EMAIL_PATTERN` 정규식 동기화
- 테스트: 이메일 검증 테스트 케이스 17개 추가

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

기존 `@Email` 어노테이션은 `test@a`, `a@b.c` 같은 TLD가 없거나 1자인 이메일도 통과시켰습니다.
RFC 5322 표준을 완벽히 구현하면 정규식이 복잡해지므로, 실용적인 수준의 간소화된 정규식을 선택했습니다:
- TLD 최소 2자 이상 필수
- 로컬 파트: 영문, 숫자, `._%+-` 허용
- 도메인: 영문, 숫자, `.-` 허용

---

## 어떻게 테스트했나요? (Test)

- 백엔드 단위 테스트 (`MemberControllerTest.signupEmailTest`)
- 백엔드 전체 테스트 통과 (`./gradlew test`)
- 프론트엔드 빌드 성공 (`pnpm build`)

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 유효한 이메일: `test@example.com`, `user.name@domain.co.kr`, `user+tag@example.org`
2. 무효한 이메일: `test@a`, `a@b.c`, `test@.com`, `@test.com`

</details>

---

## 참고사항 / 회고 메모 (Notes)

- SMTP 실제 검증은 별도 이슈로 분리: #286
- 프론트/백엔드 동일한 정규식 사용으로 일관성 확보