### PR TITLE
feat: #272 Footer에 GitHub 이슈 링크 추가

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -46,9 +46,29 @@ export default function Footer() {
                     {/* Contact */}
                     <div>
                         <h3 className="text-white font-bold text-lg mb-4">Contact</h3>
-                        <p className="text-gray-400 text-sm">
+                        <p className="text-gray-400 text-sm mb-4">
                             문의 및 피드백은 언제든 환영합니다.
                         </p>
+                        <a
+                            href="https://github.com/CheHyeonYeong/cohi-chat/issues"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-2 text-gray-400 text-sm hover:text-white transition-colors"
+                        >
+                            <svg
+                                className="w-5 h-5"
+                                fill="currentColor"
+                                viewBox="0 0 24 24"
+                                aria-hidden="true"
+                            >
+                                <path
+                                    fillRule="evenodd"
+                                    d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                                    clipRule="evenodd"
+                                />
+                            </svg>
+                            버그 리포트 / 기능 요청
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #272

---

## 📦 뭘 만들었나요? (What)

Footer의 Contact 섹션에 GitHub 이슈 페이지 링크 추가
- GitHub 아이콘 (SVG) + "버그 리포트 / 기능 요청" 텍스트
- 새 탭에서 이슈 페이지 열림

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- 아이콘 라이브러리 추가 vs SVG 직접 사용: 이 기능 하나를 위해 라이브러리를 추가하는 건 과한 것 같아서 SVG를 직접 사용함
- 링크 위치: Contact 섹션이 피드백 관련 영역이라 여기에 배치함

---

## 어떻게 테스트했나요? (Test)

로컬에서 직접 실행하여 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. Footer에서 GitHub 링크 표시 확인
2. 클릭 시 https://github.com/CheHyeonYeong/cohi-chat/issues 로 이동 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

없음