### PR TITLE
fix: AWS S3 업로드 시 와일드카드 문제 수정

### DIFF
--- a/.github/workflows/server-deploy-prod.yml
+++ b/.github/workflows/server-deploy-prod.yml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Upload JAR to S3
         run: |
-          aws s3 cp backend/build/libs/*.jar s3://cohi-chat-config/app.jar
+          JAR_FILE=$(find backend/build/libs -name "*.jar" ! -name "*-plain.jar" | head -1)
+          echo "Uploading: $JAR_FILE"
+          aws s3 cp "$JAR_FILE" s3://cohi-chat-config/app.jar
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #314 후속 수정

---

## 📦 뭘 만들었나요? (What)

GitHub Actions에서 AWS S3 업로드 시 와일드카드(*) 문제 수정

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

AWS CLI가 shell glob 패턴을 직접 지원하지 않아서 `aws s3 cp *.jar` 명령이 실패함

```bash
# 실패
aws s3 cp backend/build/libs/*.jar s3://...

# 수정
JAR_FILE=$(find ... -name "*.jar" ! -name "*-plain.jar")
aws s3 cp "$JAR_FILE" s3://...
```

`-plain.jar` 제외: Spring Boot는 실행 불가능한 plain JAR도 생성하므로 제외 처리

---

## 어떻게 테스트했나요? (Test)

- [ ] GitHub Actions 배포 파이프라인 실행

---

## 참고사항 / 회고 메모 (Notes)

#314 머지 후 배포 실패로 발견된 문제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * JAR 파일 업로드 프로세스 개선으로 배포 안정성 강화. 이제 특정 JAR 파일을 선택하여 업로드하고, 선택된 파일 경로를 기록합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->