### PR TITLE
hotfix: OAuth2 redirect URI 운영 도메인으로 설정

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,3 +1,7 @@
 # Production profile
 # 운영 환경에서도 스키마 자동 업데이트 허용 (SQLite 특성상 필요)
 spring.jpa.hibernate.ddl-auto=update
+
+# OAuth2 redirect URIs (production)
+oauth2.google.redirect-uri=https://www.cohi-chat.com/oauth/callback/google
+oauth2.kakao.redirect-uri=https://www.cohi-chat.com/oauth/callback/kakao


### PR DESCRIPTION
## Summary
- `application-prod.properties`에 Google/Kakao OAuth redirect URI를 운영 도메인(`https://www.cohi-chat.com`)으로 명시
- 기존에 환경변수 미설정 시 `localhost:3000`이 기본값으로 사용되어 배포 환경에서 OAuth 콜백 시 ERR_CONNECTION_REFUSED 발생하던 문제 수정

## Test plan
- [ ] Google Cloud Console에 `https://www.cohi-chat.com/oauth/callback/google` 등록 확인
- [ ] Kakao Developers에 `https://www.cohi-chat.com/oauth/callback/kakao` 등록 확인
- [ ] 배포 후 Google 로그인 → 계정 선택 → 정상 콜백 확인
- [ ] 배포 후 카카오 로그인 → 계정 선택 → 정상 콜백 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 환경에서 Google 및 Kakao OAuth 로그인 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->