### PR TITLE
hotfix: OAuth2 redirect URI 기본값을 운영 도메인으로 변경

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,7 +1,3 @@
 # Production profile
 # 운영 환경에서도 스키마 자동 업데이트 허용 (SQLite 특성상 필요)
 spring.jpa.hibernate.ddl-auto=update
-
-# OAuth2 redirect URIs (production)
-oauth2.google.redirect-uri=https://www.cohi-chat.com/oauth/callback/google
-oauth2.kakao.redirect-uri=https://www.cohi-chat.com/oauth/callback/kakao

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -41,11 +41,11 @@ google.calendar.timezone=Asia/Seoul
 # OAuth2
 oauth2.google.client-id=${GOOGLE_OAUTH_CLIENT_ID:}
 oauth2.google.client-secret=${GOOGLE_OAUTH_CLIENT_SECRET:}
-oauth2.google.redirect-uri=${GOOGLE_OAUTH_REDIRECT_URI:http://localhost:3000/oauth/callback/google}
+oauth2.google.redirect-uri=${GOOGLE_OAUTH_REDIRECT_URI:https://www.cohi-chat.com/oauth/callback/google}
 
 oauth2.kakao.client-id=${KAKAO_OAUTH_CLIENT_ID:}
 oauth2.kakao.client-secret=${KAKAO_OAUTH_CLIENT_SECRET:}
-oauth2.kakao.redirect-uri=${KAKAO_OAUTH_REDIRECT_URI:http://localhost:3000/oauth/callback/kakao}
+oauth2.kakao.redirect-uri=${KAKAO_OAUTH_REDIRECT_URI:https://www.cohi-chat.com/oauth/callback/kakao}
 
 # File Upload (Local Development)
 file.upload-dir=./uploads


### PR DESCRIPTION
## Summary
- `application.properties` OAuth2 redirect URI 기본값을 `localhost:3000` → `https://www.cohi-chat.com`으로 변경
- `application-prod.properties`에서 중복 설정 제거

## Test plan
- [ ] Google/Kakao 로그인 → 계정 선택 → 정상 콜백 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **설정 변경**
  * Google 및 Kakao OAuth2 redirect URI를 프로덕션 도메인으로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->