### PR TITLE
refactor: #329 프로필별 DB 설정 분리 및 docker-compose 업데이트

### DIFF
--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,14 @@
+# Development profile - SQLite
+spring.datasource.driver-class-name=org.sqlite.JDBC
+spring.datasource.url=jdbc:sqlite:${SQLITE_DB_PATH:./local.db}
+
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
+spring.jpa.hibernate.ddl-auto=update
+
+# OAuth2 redirect URIs (development)
+oauth2.google.redirect-uri=http://localhost:3000/oauth/callback/google
+oauth2.kakao.redirect-uri=http://localhost:3000/oauth/callback/kakao
+
+# Logging (verbose for development)
+logging.level.com.coDevs.cohiChat=DEBUG
+logging.level.org.springframework.web=DEBUG

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,7 +1,16 @@
-# Production profile
-# 운영 환경에서도 스키마 자동 업데이트 허용 (SQLite 특성상 필요)
+# Production profile - PostgreSQL (Supabase)
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://${SUPABASE_DB_HOST}:${SUPABASE_DB_PORT:5432}/${SUPABASE_DB_NAME:postgres}?sslmode=require
+spring.datasource.username=${SUPABASE_DB_USER:postgres}
+spring.datasource.password=${SUPABASE_DB_PASSWORD}
+
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 
 # OAuth2 redirect URIs (production)
 oauth2.google.redirect-uri=https://www.cohi-chat.com/oauth/callback/google
 oauth2.kakao.redirect-uri=https://www.cohi-chat.com/oauth/callback/kakao
+
+# Logging (reduced for production)
+logging.level.com.coDevs.cohiChat=INFO
+logging.level.org.springframework.web=WARN

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,16 +1,9 @@
 spring.application.name=cohiChat
 
-# Supabase PostgreSQL
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://${SUPABASE_DB_HOST}:${SUPABASE_DB_PORT:5432}/${SUPABASE_DB_NAME:postgres}?sslmode=require
-spring.datasource.username=${SUPABASE_DB_USER:postgres}
-spring.datasource.password=${SUPABASE_DB_PASSWORD}
-
+# DB 설정은 프로필별로 분리됨 (application-dev.properties, application-prod.properties)
+# 공통 HikariCP 설정
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=2
-
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
 
 jwt.secret=cohi-chat-secret-key-for-jwt-token-must-be-long-enough-123456
 jwt.access-token-expiration-ms=3600000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,8 +17,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
-    volumes:
-      - sqlite-data:/app/data
     env_file:
       - .env
     environment:
@@ -26,6 +24,12 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD}
+      # Supabase PostgreSQL
+      - SUPABASE_DB_HOST=${SUPABASE_DB_HOST}
+      - SUPABASE_DB_PORT=${SUPABASE_DB_PORT:-5432}
+      - SUPABASE_DB_NAME=${SUPABASE_DB_NAME:-postgres}
+      - SUPABASE_DB_USER=${SUPABASE_DB_USER}
+      - SUPABASE_DB_PASSWORD=${SUPABASE_DB_PASSWORD}
     depends_on:
       redis:
         condition: service_healthy
@@ -45,7 +49,5 @@ services:
     restart: unless-stopped
 
 volumes:
-  sqlite-data:
-    driver: local
   redis-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,12 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-devpassword}
-      - SQLITE_DB_PATH=/app/data/cohi-chat.db
-    volumes:
-      - sqlite-data:/app/data
+      # Supabase PostgreSQL
+      - SUPABASE_DB_HOST=${SUPABASE_DB_HOST}
+      - SUPABASE_DB_PORT=${SUPABASE_DB_PORT:-5432}
+      - SUPABASE_DB_NAME=${SUPABASE_DB_NAME:-postgres}
+      - SUPABASE_DB_USER=${SUPABASE_DB_USER}
+      - SUPABASE_DB_PASSWORD=${SUPABASE_DB_PASSWORD}
     networks:
       - cohi-chat-network
     depends_on:
@@ -74,7 +77,3 @@ networks:
 volumes:
   redis-data:
     driver: local
-  sqlite-data:
-    driver: local
-  # Uncomment if you need persistent volumes
-  # postgres-data:


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #329

---

## 📦 뭘 만들었나요? (What)

프로필별 DB 설정 분리로 배포 시 502 에러 문제 해결

| 파일 | 변경 내용 |
|------|----------|
| `application.properties` | DB 설정 제거, 공통 HikariCP 설정만 유지 |
| `application-dev.properties` | 신규 생성 - SQLite 설정 (로컬 개발용) |
| `application-prod.properties` | PostgreSQL(Supabase) 설정 추가 |
| `docker-compose.yml` | SQLite 볼륨 제거, Supabase 환경변수 추가 |
| `docker-compose.prod.yml` | SQLite 볼륨 제거, Supabase 환경변수 추가 |

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

기존 문제:
- `application.properties`에 PostgreSQL 드라이버/dialect가 하드코딩
- 서버 `.env`에서 `SPRING_DATASOURCE_URL`만 SQLite로 오버라이드
- 드라이버와 URL 불일치로 502 에러 반복 발생

해결 방안:
- 프로필별로 DB 설정을 완전히 분리 (dev=SQLite, prod=PostgreSQL)
- `SPRING_PROFILES_ACTIVE=prod`만 설정하면 자동으로 PostgreSQL 사용
- 환경변수 오버라이드 없이 프로필만으로 DB 전환 가능

---

## 어떻게 테스트했나요? (Test)

- `./gradlew test` 통과 확인
- 로컬 빌드 성공

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 로컬에서 dev 프로필로 SQLite 연결 확인
2. prod 프로필 설정 시 PostgreSQL 환경변수 필요 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

**서버 배포 시 필요한 작업:**
1. 서버 `.env` 파일에서 `SPRING_DATASOURCE_URL=jdbc:sqlite:...` 라인 제거
2. Supabase 환경변수 추가:
   - `SUPABASE_DB_HOST`
   - `SUPABASE_DB_PORT` (기본값 5432)
   - `SUPABASE_DB_NAME` (기본값 postgres)
   - `SUPABASE_DB_USER`
   - `SUPABASE_DB_PASSWORD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 데이터베이스 설정을 PostgreSQL로 변경
  * 개발/프로덕션 환경별 설정 파일 분리
  * 로깅 레벨 구성 추가
  * Docker 컨테이너 환경 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->