### PR TITLE
fix: Docker 빌드 시 --no-cache 제거로 캐시 활용

### DIFF
--- a/.github/workflows/server-deploy-prod.yml
+++ b/.github/workflows/server-deploy-prod.yml
@@ -83,7 +83,7 @@ jobs:
             docker system prune -af \
               --filter "label=com.docker.compose.project=cohi-chat" || true
 
-            docker-compose -f docker-compose.prod.yml build --no-cache backend
+            docker-compose -f docker-compose.prod.yml build backend
             docker-compose -f docker-compose.prod.yml up -d redis backend
 
             echo "Waiting for backend to start..."


### PR DESCRIPTION
## 🔗 관련 이슈
- N/A (핫픽스)

---

## 📦 뭘 만들었나요? (What)

EC2 배포 시 Docker 빌드 `--no-cache` 옵션 제거

```yaml
# Before
docker-compose -f docker-compose.prod.yml build --no-cache backend

# After
docker-compose -f docker-compose.prod.yml build backend
```

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- EC2 인스턴스 메모리가 1GB로 제한적
- `--no-cache` 옵션으로 매번 처음부터 빌드 → 스왑 사용 → 타임아웃 발생
- 캐시 활용하면 변경된 레이어만 빌드하여 속도 개선

---

## 어떻게 테스트했나요? (Test)

- 배포 후 확인 필요

---

## 참고사항 / 회고 메모 (Notes)

근본적인 해결책은 GitHub Actions에서 Docker 이미지 빌드 → 레지스트리 푸시 → EC2는 pull만 하는 방식이나, 일단 빠른 해결을 위해 캐시 활용으로 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로덕션 배포 워크플로우의 빌드 캐싱 설정을 최적화하여 배포 프로세스 효율성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->