### PR TITLE
fix: 클라이언트 배포 시 --no-cache, --volumes 제거로 캐시 활용

### DIFF
--- a/.github/workflows/client-deploy-prod.yml
+++ b/.github/workflows/client-deploy-prod.yml
@@ -77,10 +77,11 @@ jobs:
             aws s3 cp s3://cohi-chat-config/.env .env
 
             # Free up disk space before build (cohi-chat project only)
-            docker system prune -af --volumes \
+            # Note: --volumes 제거 - 캐시 볼륨 보호
+            docker system prune -af \
               --filter "label=com.docker.compose.project=cohi-chat" || true
 
-            docker-compose -f docker-compose.prod.yml build --no-cache frontend
+            docker-compose -f docker-compose.prod.yml build frontend
             docker-compose -f docker-compose.prod.yml up -d frontend
 
             echo "Waiting for frontend to start..."


### PR DESCRIPTION
## 🔗 관련 이슈
- N/A (핫픽스)

---

## 📦 뭘 만들었나요? (What)

클라이언트 배포 워크플로우에서 캐시 관련 옵션 제거

```yaml
# Before
docker system prune -af --volumes
docker-compose build --no-cache frontend

# After  
docker system prune -af
docker-compose build frontend
```

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- `--volumes` 옵션으로 Docker 볼륨(pnpm 캐시 포함) 삭제됨
- 매 배포마다 635개 패키지를 처음부터 다운로드 → 20분 소요
- 캐시 활용하면 2~3분으로 단축

---

## 어떻게 테스트했나요? (Test)

- 배포 후 시간 확인 필요

---

## 참고사항 / 회고 메모 (Notes)

server-deploy-prod.yml은 이미 PR #331에서 수정 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 프로덕션 배포 프로세스의 빌드 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->