### PR TITLE
refactor: #289 ErrorCode 정리 및 tdd-issue.md 하드코딩 제거

### DIFF
--- a/.claude/skills/tdd-issue/SKILL.md
+++ b/.claude/skills/tdd-issue/SKILL.md
@@ -1,4 +1,4 @@
-# TDD 기반 이슈 개발
+﻿# TDD 기반 이슈 개발
 
 > GitHub 이슈를 TDD 방식으로 개발하는 워크플로우
 
@@ -13,7 +13,7 @@
 ## 작업 순서
 
 1. **브랜치 생성**: `{작성자이니셜}_$ARGUMENTS` 형식으로 브랜치 생성 (예: `khs_82`, `chy_82`)
-2. **이슈 확인**: GitHub 이슈 조회 → `https://github.com/CheHyeonYeong/cohi-chat/issues/$ARGUMENTS`
+2. **이슈 확인**: GitHub CLI(`gh issue view $ARGUMENTS`)를 통해 이슈 내용 확인
 3. **실행 계획 작성**: `.claude/issue/$ARGUMENTS.md`에 checkpoint 단위로 계획 작성
 4. **순차 작업**: 작성된 계획 파일을 보면서 checkpoint 순서대로 진행
 5. **TDD 사이클**: 테스트 작성 → 실패 확인 → 구현 → 테스트 통과 → 리팩토링
@@ -48,3 +48,5 @@
 ## 시작하기
 
 이슈 번호 `$ARGUMENTS`에서 숫자를 추출하여 위 작업을 순서대로 진행해주세요.
+
+

--- a/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
 	INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
 
 	DUPLICATED_USERNAME(HttpStatus.CONFLICT, "중복된 계정 ID입니다."),
+
+	ALREADY_HOST(HttpStatus.CONFLICT, "이미 호스트로 등록되어 있습니다."),
 	DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 E-mail 주소입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 없습니다."),
 
@@ -37,8 +39,6 @@ public enum ErrorCode {
 	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
 	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
 	AUTH_NOT_PROVIDED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
-
-	ALREADY_HOST(HttpStatus.CONFLICT, "이미 호스트로 등록되어 있습니다."),
 
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 정보에 접근할 권한이 없습니다."),
     GUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게스트 권한으로는 이용할 수 없는 기능입니다."),


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #289

---

## 📝 무엇을 만들었나요? (What)
- \ErrorCode.java\ 파일 내 \ALREADY_HOST\의 위치를 다른 \HttpStatus.CONFLICT\ 관련 에러코드들 근처로 이동시켜 일관성을 높였습니다.
- \.claude/skills/tdd-issue/SKILL.md\ 스킬 정의 문서에 하드코딩되어 있던 레포지토리 이름을 GitHub CLI(\gh issue view\)를 사용하는 범용적인 방식으로 교체했습니다.

---

## 🤔 이렇게 만들었어요 (Why)
- 에러 코드 그룹핑을 통한 가독성 및 유지보수성 향상.
- TDD 스킬의 재사용성 개선.

---

## ✅ 어떻게 테스트했나요? (Test)
- 로컬 컴파일 및 백엔드 테스트 확인 완료.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 호스트로 이미 등록된 사용자의 중복 등록 시도 시 명확한 오류 메시지 제공

* **문서**
  * 개발 프로세스 설명서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->