### PR TITLE
feat: #321 #276 닉네임, 비밀번호 수정 페이지 및 한글 이름 생성기 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query": "^5.61.0",
     "@tanstack/react-router": "^1.82.2",
     "add": "^2.0.6",
+    "korean-name-generator": "^1.0.4",
     "pnpm": "^9.14.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       add:
         specifier: ^2.0.6
         version: 2.0.6
+      korean-name-generator:
+        specifier: ^1.0.4
+        version: 1.0.4
       pnpm:
         specifier: ^9.14.2
         version: 9.15.1
@@ -1072,51 +1075,61 @@ packages:
     resolution: {integrity: sha512-Py5vFd5HWYN9zxBv3WMrLAXY3yYJ6Q/aVERoeUFwiDGiMOWsMs7FokXihSOaT/PMWUty/Pj60XDQndK3eAfE6A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.29.1':
     resolution: {integrity: sha512-RiWpGgbayf7LUcuSNIbahr0ys2YnEERD4gYdISA06wa0i8RALrnzflh9Wxii7zQJEB2/Eh74dX4y/sHKLWp5uQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.29.1':
     resolution: {integrity: sha512-Z80O+taYxTQITWMjm/YqNoe9d10OX6kDh8X5/rFCMuPqsKsSyDilvfg+vd3iXIqtfmp+cnfL1UrYirkaF8SBZA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.29.1':
     resolution: {integrity: sha512-fOHRtF9gahwJk3QVp01a/GqS4hBEZCV1oKglVVq13kcK3NeVlS4BwIFzOHDbmKzt3i0OuHG4zfRP0YoG5OF/rA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.29.1':
     resolution: {integrity: sha512-5a7q3tnlbcg0OodyxcAdrrCxFi0DgXJSoOuidFUzHZ2GixZXQs6Tc3CHmlvqKAmOs5eRde+JJxeIf9DonkmYkw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.29.1':
     resolution: {integrity: sha512-9b4Mg5Yfz6mRnlSPIdROcfw1BU22FQxmfjlp/CShWwO3LilKQuMISMTtAu/bxmmrE6A902W2cZJuzx8+gJ8e9w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.29.1':
     resolution: {integrity: sha512-G5pn0NChlbRM8OJWpJFMX4/i8OEU538uiSv0P6roZcbpe/WfhEO+AT8SHVKfp8qhDQzaz7Q+1/ixMy7hBRidnQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.29.1':
     resolution: {integrity: sha512-WM9lIkNdkhVwiArmLxFXpWndFGuOka4oJOZh8EP3Vb8q5lzdSCBuhjavJsw68Q9AKDGeOOIHYzYm4ZFvmWez5g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.29.1':
     resolution: {integrity: sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.29.1':
     resolution: {integrity: sha512-xufkSNppNOdVRCEC4WKvlR1FBDyqCSCpQeMMgv9ZyXqqtKBfkw1yfGMTUTs9Qsl6WQbJnsGboWCp7pJGkeMhKA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.29.1':
     resolution: {integrity: sha512-F2OiJ42m77lSkizZQLuC+jiZ2cgueWQL5YC9tjo3AgaEw+KJmVxHGSyQfDUoYR9cci0lAywv2Clmckzulcq6ig==}
@@ -1156,24 +1169,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.10.1':
     resolution: {integrity: sha512-x0L2Pd9weQ6n8dI1z1Isq00VHFvpBClwQJvrt3NHzmR+1wCT/gcYl1tp9P5xHh3ldM8Cn4UjWCw+7PaUgg8FcQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.10.1':
     resolution: {integrity: sha512-yyYEwQcObV3AUsC79rSzN9z6kiWxKAVJ6Ntwq2N9YoZqSPYph+4/Am5fM1xEQYf/kb99csj0FgOelomJSobxQA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.10.1':
     resolution: {integrity: sha512-tcaS43Ydd7Fk7sW5ROpaf2Kq1zR+sI5K0RM+0qYLYYurvsJruj3GhBCaiN3gkzd8m/8wkqNqtVklWaQYSDsyqA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.10.1':
     resolution: {integrity: sha512-D3Qo1voA7AkbOzQ2UGuKNHfYGKL6eejN8VWOoQYtGHHQi1p5KK/Q7V1ku55oxXBsj79Ny5FRMqiRJpVGad7bjQ==}
@@ -2337,6 +2354,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  korean-name-generator@1.0.4:
+    resolution: {integrity: sha512-iIxlar4KRYg+wVsfDs6HIrAD8Z4UkCPtIzINckNXzE4paABXYDZQx4GeTA4YxU6zHxD9d+WLS7NdykqzKj/8Xw==}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -5664,6 +5684,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  korean-name-generator@1.0.4: {}
 
   language-subtag-registry@0.3.23: {}
 

--- a/frontend/src/features/member/api/memberApi.ts
+++ b/frontend/src/features/member/api/memberApi.ts
@@ -8,6 +8,7 @@ import type {
     MemberResponseDTO,
     HostResponseDTO,
     UpdateProfilePayload,
+    UpdateMemberPayload,
 } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080/api';
@@ -81,6 +82,17 @@ export async function updateProfileApi(payload: UpdateProfilePayload): Promise<H
     });
     if (!response) {
         throw new Error('프로필 업데이트에 실패했습니다.');
+    }
+    return response;
+}
+
+export async function updateMemberApi(username: string, payload: UpdateMemberPayload): Promise<MemberResponseDTO> {
+    const response = await httpClient<MemberResponseDTO>(`${MEMBER_API}/${encodeURIComponent(username)}`, {
+        method: 'PATCH',
+        body: payload,
+    });
+    if (!response) {
+        throw new Error('회원 정보 수정에 실패했습니다.');
     }
     return response;
 }

--- a/frontend/src/features/member/components/PasswordChangeForm.tsx
+++ b/frontend/src/features/member/components/PasswordChangeForm.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import Button from '~/components/button/Button';
+import { useAuth } from '../hooks/useAuth';
+import { useUpdateMember } from '../hooks/useUpdateMember';
+import { useFormValidation, type ValidationRule } from '../hooks/useFormValidation';
+import { getErrorMessage } from '~/libs/errorUtils';
+
+const PASSWORD_PATTERN = /^[a-zA-Z0-9!@#$%^&*._-]{8,20}$/;
+
+interface PasswordFormValues {
+    newPassword: string;
+    confirmPassword: string;
+}
+
+const createValidationRules = (
+    getNewPassword: () => string
+): Record<keyof PasswordFormValues, ValidationRule<string>> => ({
+    newPassword: (value: string) => {
+        if (!value) return '새 비밀번호를 입력해주세요.';
+        if (!PASSWORD_PATTERN.test(value)) {
+            return '비밀번호는 8~20자의 영문, 숫자, 특수문자(!@#$%^&*._-)만 가능합니다.';
+        }
+        return null;
+    },
+    confirmPassword: (value: string) => {
+        if (!value) return '비밀번호 확인을 입력해주세요.';
+        if (value !== getNewPassword()) {
+            return '비밀번호가 일치하지 않습니다.';
+        }
+        return null;
+    },
+});
+
+export function PasswordChangeForm() {
+    const { data: user } = useAuth();
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [successMessage, setSuccessMessage] = useState('');
+    const mutation = useUpdateMember(user?.username ?? '');
+
+    const validationRules = createValidationRules(() => newPassword);
+    const { fields, handleBlur, validateAll, getInputClassName } =
+        useFormValidation<PasswordFormValues>(validationRules);
+
+    const baseInputClass =
+        'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors';
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        setSuccessMessage('');
+
+        const values: PasswordFormValues = { newPassword, confirmPassword };
+        if (!validateAll(values)) return;
+
+        mutation.mutate(
+            { password: newPassword },
+            {
+                onSuccess: () => {
+                    setNewPassword('');
+                    setConfirmPassword('');
+                    setSuccessMessage('비밀번호가 변경되었습니다.');
+                },
+            }
+        );
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4" data-testid="password-change-form">
+            <h3 className="text-lg font-semibold text-[var(--cohe-text-dark)]">비밀번호 변경</h3>
+
+            <div className="flex flex-col gap-1">
+                <label htmlFor="newPassword" className="text-sm text-[var(--cohe-text-dark)]">
+                    새 비밀번호
+                </label>
+                <input
+                    type="password"
+                    id="newPassword"
+                    data-testid="new-password-input"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    onBlur={() => handleBlur('newPassword', newPassword)}
+                    disabled={mutation.isPending}
+                    minLength={8}
+                    maxLength={20}
+                    placeholder="(8-20자)"
+                    className={getInputClassName('newPassword', baseInputClass)}
+                />
+                {fields.newPassword?.touched && fields.newPassword.error && (
+                    <span className="text-xs text-red-500 mt-1">{fields.newPassword.error}</span>
+                )}
+            </div>
+
+            <div className="flex flex-col gap-1">
+                <label htmlFor="confirmPassword" className="text-sm text-[var(--cohe-text-dark)]">
+                    비밀번호 확인
+                </label>
+                <input
+                    type="password"
+                    id="confirmPassword"
+                    data-testid="confirm-password-input"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    onBlur={() => handleBlur('confirmPassword', confirmPassword)}
+                    disabled={mutation.isPending}
+                    minLength={8}
+                    maxLength={20}
+                    placeholder="비밀번호 확인"
+                    className={getInputClassName('confirmPassword', baseInputClass)}
+                />
+                {fields.confirmPassword?.touched && fields.confirmPassword.error && (
+                    <span className="text-xs text-red-500 mt-1">{fields.confirmPassword.error}</span>
+                )}
+            </div>
+
+            {mutation.isError && (
+                <div className="text-red-600 text-sm">
+                    {getErrorMessage(mutation.error, '비밀번호 변경에 실패했습니다.')}
+                </div>
+            )}
+
+            {successMessage && (
+                <div className="text-green-600 text-sm" data-testid="password-success-message">
+                    {successMessage}
+                </div>
+            )}
+
+            <Button
+                variant="primary"
+                type="submit"
+                disabled={mutation.isPending}
+                className="w-full rounded-lg"
+            >
+                {mutation.isPending ? '변경 중...' : '비밀번호 변경'}
+            </Button>
+        </form>
+    );
+}

--- a/frontend/src/features/member/components/ProfileEditForm.tsx
+++ b/frontend/src/features/member/components/ProfileEditForm.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import Button from '~/components/button/Button';
+import { useAuth } from '../hooks/useAuth';
+import { useUpdateMember } from '../hooks/useUpdateMember';
+import { useFormValidation, type ValidationRule } from '../hooks/useFormValidation';
+import { getErrorMessage } from '~/libs/errorUtils';
+
+interface ProfileFormValues {
+    displayName: string;
+}
+
+const validationRules: Record<keyof ProfileFormValues, ValidationRule<string>> = {
+    displayName: (value: string) => {
+        const trimmed = value.trim();
+        if (!trimmed) return '표시 이름을 입력해주세요.';
+        if (trimmed.length < 2 || trimmed.length > 20) {
+            return '표시 이름은 2~20자여야 합니다.';
+        }
+        return null;
+    },
+};
+
+export function ProfileEditForm() {
+    const { data: user } = useAuth();
+    const [displayName, setDisplayName] = useState(user?.displayName ?? '');
+    const [successMessage, setSuccessMessage] = useState('');
+    const mutation = useUpdateMember(user?.username ?? '');
+
+    const { fields, handleBlur, validateAll, getInputClassName } =
+        useFormValidation<ProfileFormValues>(validationRules);
+
+    const baseInputClass =
+        'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors';
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        setSuccessMessage('');
+
+        const values: ProfileFormValues = { displayName: displayName.trim() };
+        if (!validateAll(values)) return;
+
+        mutation.mutate(
+            { displayName: displayName.trim() },
+            {
+                onSuccess: () => {
+                    setSuccessMessage('표시 이름이 변경되었습니다.');
+                },
+            }
+        );
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4" data-testid="profile-edit-form">
+            <h3 className="text-lg font-semibold text-[var(--cohe-text-dark)]">표시 이름 변경</h3>
+
+            <div className="flex flex-col gap-1">
+                <label htmlFor="displayName" className="text-sm text-[var(--cohe-text-dark)]">
+                    표시 이름
+                </label>
+                <input
+                    type="text"
+                    id="displayName"
+                    data-testid="display-name-input"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    onBlur={() => handleBlur('displayName', displayName)}
+                    disabled={mutation.isPending}
+                    maxLength={20}
+                    placeholder="(2-20자)"
+                    className={getInputClassName('displayName', baseInputClass)}
+                />
+                {fields.displayName?.touched && fields.displayName.error && (
+                    <span className="text-xs text-red-500 mt-1">{fields.displayName.error}</span>
+                )}
+            </div>
+
+            {mutation.isError && (
+                <div className="text-red-600 text-sm">
+                    {getErrorMessage(mutation.error, '표시 이름 변경에 실패했습니다.')}
+                </div>
+            )}
+
+            {successMessage && (
+                <div className="text-green-600 text-sm" data-testid="profile-success-message">
+                    {successMessage}
+                </div>
+            )}
+
+            <Button
+                variant="primary"
+                type="submit"
+                disabled={mutation.isPending}
+                className="w-full rounded-lg"
+            >
+                {mutation.isPending ? '변경 중...' : '변경하기'}
+            </Button>
+        </form>
+    );
+}

--- a/frontend/src/features/member/components/SignupForm.tsx
+++ b/frontend/src/features/member/components/SignupForm.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
+import { generate as generateKoreanName } from 'korean-name-generator';
 import Button from '~/components/button/Button';
 import { useSignup } from '../hooks/useSignup';
 import { useFormValidation, type ValidationRule } from '../hooks/useFormValidation';
@@ -80,13 +81,20 @@ export function SignupForm() {
         [handleBlur]
     );
 
+    const handleRandomName = () => {
+        const randomName = generateKoreanName();
+        setDisplayName(randomName);
+    };
+
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
+
+        const finalDisplayName = displayName.trim() || generateKoreanName();
 
         const values: SignupFormValues = {
             username: username.trim(),
             email: email.trim(),
-            displayName: displayName.trim(),
+            displayName: finalDisplayName,
             password,
             passwordAgain,
         };
@@ -99,7 +107,7 @@ export function SignupForm() {
             {
                 username: username.trim(),
                 email: email.trim(),
-                displayName: displayName.trim() || undefined,
+                displayName: finalDisplayName,
                 password,
             },
             {
@@ -162,23 +170,43 @@ export function SignupForm() {
                         {fields.email?.touched && fields.email.error && (
                             <span className="text-xs text-red-500 mt-1">{fields.email.error}</span>
                         )}
+                        {fields.email?.touched && fields.email.isValid && (
+                            <span className="text-xs text-green-500 mt-1 flex items-center gap-1" data-testid="email-valid-indicator">
+                                <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                                </svg>
+                                이메일 형식이 올바릅니다
+                            </span>
+                        )}
                     </div>
 
                     <div className="flex flex-col gap-1">
                         <label htmlFor="displayName" className="text-sm text-[var(--cohe-text-dark)]">
                             표시 이름 (선택)
                         </label>
-                        <input
-                            type="text"
-                            id="displayName"
-                            value={displayName}
-                            onChange={(e) => setDisplayName(e.target.value)}
-                            onBlur={() => onBlur('displayName', displayName)}
-                            disabled={isPending}
-                            maxLength={20}
-                            placeholder="(2-20자)"
-                            className={getInputClassName('displayName', baseInputClass)}
-                        />
+                        <div className="flex gap-2">
+                            <input
+                                type="text"
+                                id="displayName"
+                                value={displayName}
+                                onChange={(e) => setDisplayName(e.target.value)}
+                                onBlur={() => onBlur('displayName', displayName)}
+                                disabled={isPending}
+                                maxLength={20}
+                                placeholder="(2-20자)"
+                                className={getInputClassName('displayName', baseInputClass)}
+                            />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={handleRandomName}
+                                disabled={isPending}
+                                className="whitespace-nowrap flex-shrink-0"
+                                data-testid="random-name-button"
+                            >
+                                랜덤 생성
+                            </Button>
+                        </div>
                         {fields.displayName?.touched && fields.displayName.error && (
                             <span className="text-xs text-red-500 mt-1">{fields.displayName.error}</span>
                         )}

--- a/frontend/src/features/member/hooks/useUpdateMember.ts
+++ b/frontend/src/features/member/hooks/useUpdateMember.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateMemberApi } from '../api/memberApi';
+import type { UpdateMemberPayload, MemberResponseDTO } from '../types';
+
+export function useUpdateMember(username: string) {
+    const queryClient = useQueryClient();
+    return useMutation<MemberResponseDTO, Error, UpdateMemberPayload>({
+        mutationFn: (payload) => updateMemberApi(username, payload),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['auth'] });
+        },
+    });
+}

--- a/frontend/src/features/member/index.ts
+++ b/frontend/src/features/member/index.ts
@@ -5,10 +5,13 @@ export { useOAuthLogin } from './hooks/useOAuthLogin';
 export { useLogout } from './hooks/useLogout';
 export { useSignup } from './hooks/useSignup';
 export { useUpdateProfile } from './hooks/useUpdateProfile';
+export { useUpdateMember } from './hooks/useUpdateMember';
 
 // components
 export { LoginForm } from './components/LoginForm';
 export { SignupForm } from './components/SignupForm';
+export { ProfileEditForm } from './components/ProfileEditForm';
+export { PasswordChangeForm } from './components/PasswordChangeForm';
 
 // types
 export type {
@@ -24,4 +27,5 @@ export type {
     SignupPayload,
     SignupResponse,
     UpdateProfilePayload,
+    UpdateMemberPayload,
 } from './types';

--- a/frontend/src/features/member/types/index.ts
+++ b/frontend/src/features/member/types/index.ts
@@ -67,3 +67,8 @@ export interface UpdateProfilePayload {
     job?: string;
     profileImageUrl?: string;
 }
+
+export interface UpdateMemberPayload {
+    displayName?: string;
+    password?: string;
+}

--- a/frontend/src/pages/main/Home.tsx
+++ b/frontend/src/pages/main/Home.tsx
@@ -80,6 +80,11 @@ export default function Home() {
                             </LinkButton>
                         )
                     )}
+                    {isAuthenticated && (
+                        <LinkButton variant="outline" to='/settings'>
+                            설정
+                        </LinkButton>
+                    )}
                     {isAuthenticated
                         ? <LogoutButton />
                         : <LinkButton variant="outline" to='/login'>

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,0 +1,28 @@
+import { Header } from '~/components/header';
+import { ProfileEditForm } from '~/features/member/components/ProfileEditForm';
+import { PasswordChangeForm } from '~/features/member/components/PasswordChangeForm';
+import { LogoutButton } from '~/components/button/LogoutButton';
+
+export default function Settings() {
+    return (
+        <div className="w-full min-h-screen bg-[var(--cohe-bg-light)]">
+            <Header right={<LogoutButton />} />
+
+            <div className="w-full max-w-md mx-auto px-6 py-8">
+                <h2 className="text-2xl font-bold text-[var(--cohe-text-dark)] mb-8" data-testid="settings-title">
+                    설정
+                </h2>
+
+                <div className="flex flex-col gap-8">
+                    <div className="bg-white rounded-2xl shadow-md p-8">
+                        <ProfileEditForm />
+                    </div>
+
+                    <div className="bg-white rounded-2xl shadow-md p-8">
+                        <PasswordChangeForm />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/settings/SettingsGuarded.tsx
+++ b/frontend/src/pages/settings/SettingsGuarded.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { useAuth } from '~/features/member';
+import Settings from './Settings';
+
+export default function SettingsGuarded() {
+    const { isAuthenticated, isLoading } = useAuth();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (isLoading) return;
+        if (!isAuthenticated) {
+            navigate({ to: '/login' });
+        }
+    }, [isAuthenticated, isLoading, navigate]);
+
+    if (isLoading) {
+        return (
+            <div className="w-full min-h-screen bg-[var(--cohe-bg-light)] flex items-center justify-center">
+                <p className="text-gray-500">확인 중...</p>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) return null;
+
+    return <Settings />;
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import MyBookings from '~/pages/calendar/MyBookings'
 import Booking from '~/pages/calendar/Booking'
 import HostRegisterGuarded from '~/pages/host/HostRegisterGuarded'
 import TimeSlotSettingsGuarded from '~/pages/host/TimeSlotSettingsGuarded'
+import SettingsGuarded from '~/pages/settings/SettingsGuarded'
 import Footer from '~/components/Footer'
 import Terms from '~/pages/legal/Terms'
 import Privacy from '~/pages/legal/Privacy'
@@ -136,6 +137,12 @@ const privacyRoute = createRoute({
     component: Privacy,
 })
 
+const settingsRoute = createRoute({
+    getParentRoute: () => RootRoute,
+    path: '/settings',
+    component: SettingsGuarded,
+})
+
 export const routeTree = RootRoute.addChildren([
     homeRoute,
     calendarRoute,
@@ -148,6 +155,7 @@ export const routeTree = RootRoute.addChildren([
     oAuthCallbackRoute,
     termsRoute,
     privacyRoute,
+    settingsRoute,
 ])
 
 export const router = createRouter({ routeTree })

--- a/frontend/src/types/korean-name-generator.d.ts
+++ b/frontend/src/types/korean-name-generator.d.ts
@@ -1,0 +1,3 @@
+declare module 'korean-name-generator' {
+    export function generate(isMale?: boolean): string;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #321
- Closes #276

---

## 📦 뭘 만들었나요? (What)

### #321 — 닉네임/비밀번호 수정 Settings 페이지
- `/settings` 경로에 프로필 설정 페이지 생성
- `ProfileEditForm`: 표시 이름(displayName) 변경 폼 (2-20자 유효성 검증)
- `PasswordChangeForm`: 비밀번호 변경 폼 (8-20자, 확인 일치 검증)
- `SettingsGuarded`: 인증 가드 (미인증 시 /login 리다이렉트)
- `useUpdateMember`: TanStack Query mutation hook (PATCH /api/members/v1/{username})
- Home 헤더에 설정 링크 추가

### #276 — displayName 한글 이름 생성기
- `korean-name-generator` 패키지 설치
- SignupForm에 "랜덤 생성" 버튼 추가
- displayName 미입력 시 회원가입 시 자동으로 한글 이름 생성

---

## 왜 이렇게 만들었나요? (Why)

- Settings 페이지를 ProfileEditForm / PasswordChangeForm으로 분리하여 단일 책임 원칙 준수
- 기존 PATCH /api/members/v1/{username} API를 그대로 활용하여 BE 수정 없이 구현
- korean-name-generator 라이브러리는 가볍고 한글 이름 생성에 특화되어 선택

---

## 어떻게 테스트했나요? (Test)

- `pnpm build`: 성공 (237 modules)
- `pnpm test`: 12 파일, 119 테스트 모두 통과
- `pnpm lint`: 0 errors

<details>
<summary>테스트 시나리오</summary>

| # | 시나리오 | 기대 결과 |
|---|---------|-----------|
| 1 | 로그인 후 /settings 페이지 접근 | 프로필 설정 페이지 정상 렌더링 |
| 2 | 닉네임을 새 값으로 변경 후 저장 | 성공 메시지 + 변경된 닉네임 반영 |
| 3 | 닉네임을 1자로 입력 후 저장 시도 | 유효성 검증 에러 표시 (2-20자) |
| 4 | 비밀번호 변경 후 저장 | 성공 메시지 |
| 5 | 비밀번호 8자 미만 입력 | 유효성 검증 에러 표시 |
| 6 | 회원가입 시 displayName 미입력 | 한글 이름 자동 생성 |
| 7 | 회원가입 시 랜덤 생성 버튼 클릭 | 한글 이름이 displayName 필드에 자동 입력 |
| 8 | 비로그인 상태에서 /settings 접근 | 로그인 페이지로 리다이렉트 |

</details>

---

## 참고사항 / 회고 메모 (Notes)

- FE only PR (BE API 이미 존재)
- data-testid 속성 추가 완료 (테스트 셀렉터 규칙 준수)
- Header, Button, useFormValidation 훅 등 기존 패턴 준수