### PR TITLE
refactor: #165 스트리밍 예약 조회 API Stream 기반 메모리 효율 개선

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingRepository.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingRepository.java
@@ -4,10 +4,16 @@ import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.QueryHint;
+
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
 
 import com.coDevs.cohiChat.booking.entity.AttendanceStatus;
 import com.coDevs.cohiChat.booking.entity.Booking;
@@ -15,18 +21,20 @@ import com.coDevs.cohiChat.booking.entity.Booking;
 public interface BookingRepository extends JpaRepository<Booking, Long> {
 
     /**
-     * 게스트 ID로 예약 목록 조회 (예약 날짜 내림차순)
-     * FETCH JOIN으로 N+1 문제 방지
+     * 게스트 ID로 예약 스트림 조회 (예약 날짜 내림차순)
+     * FETCH JOIN으로 N+1 문제 방지, 100개 단위 배치 조회
      */
+    @QueryHints(@QueryHint(name = HINT_FETCH_SIZE, value = "100"))
     @Query("SELECT b FROM Booking b LEFT JOIN FETCH b.timeSlot WHERE b.guestId = :guestId ORDER BY b.bookingDate DESC")
-    List<Booking> findByGuestIdOrderByBookingDateDesc(@Param("guestId") UUID guestId);
+    Stream<Booking> streamByGuestIdOrderByBookingDateDesc(@Param("guestId") UUID guestId);
 
     /**
-     * 호스트 ID로 예약 목록 조회 (TimeSlot의 userId가 호스트 ID인 예약, 예약 날짜 내림차순)
-     * FETCH JOIN으로 N+1 문제 방지
+     * 호스트 ID로 예약 스트림 조회 (TimeSlot의 userId가 호스트 ID인 예약, 예약 날짜 내림차순)
+     * FETCH JOIN으로 N+1 문제 방지, 100개 단위 배치 조회
      */
+    @QueryHints(@QueryHint(name = HINT_FETCH_SIZE, value = "100"))
     @Query("SELECT b FROM Booking b JOIN FETCH b.timeSlot t WHERE t.userId = :hostId ORDER BY b.bookingDate DESC")
-    List<Booking> findByHostIdOrderByBookingDateDesc(@Param("hostId") UUID hostId);
+    Stream<Booking> streamByHostIdOrderByBookingDateDesc(@Param("hostId") UUID hostId);
 
     /**
      * 특정 타임슬롯과 날짜에 취소되지 않은 예약이 존재하는지 확인

--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
@@ -5,10 +5,15 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jakarta.persistence.EntityManager;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +48,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class BookingService {
 
+    private static final int BATCH_FLUSH_SIZE = 100;
+
     private final BookingRepository bookingRepository;
     private final TimeSlotRepository timeSlotRepository;
     private final CalendarRepository calendarRepository;
@@ -50,6 +57,7 @@ public class BookingService {
     private final NoShowHistoryRepository noShowHistoryRepository;
     private final GoogleCalendarService googleCalendarService;
     private final GoogleCalendarProperties googleCalendarProperties;
+    private final EntityManager entityManager;
 
     private volatile ZoneId calendarZoneId;
 
@@ -198,14 +206,41 @@ public class BookingService {
 
     @Transactional(readOnly = true)
     public List<BookingResponseDTO> getBookingsByGuestId(UUID guestId) {
-        List<Booking> bookings = bookingRepository.findByGuestIdOrderByBookingDateDesc(guestId);
-        return toBookingResponseDTOs(bookings);
+        try (Stream<Booking> bookingStream = bookingRepository.streamByGuestIdOrderByBookingDateDesc(guestId)) {
+            return processBookingStreamWithBatchFlush(bookingStream);
+        }
     }
 
     @Transactional(readOnly = true)
     public List<BookingResponseDTO> getBookingsByHostId(UUID hostId) {
-        List<Booking> bookings = bookingRepository.findByHostIdOrderByBookingDateDesc(hostId);
-        return toBookingResponseDTOs(bookings);
+        try (Stream<Booking> bookingStream = bookingRepository.streamByHostIdOrderByBookingDateDesc(hostId)) {
+            return processBookingStreamWithBatchFlush(bookingStream);
+        }
+    }
+
+    /**
+     * 예약 스트림을 처리하며 100개 단위로 영속성 컨텍스트에서 detach하여 메모리 효율을 개선합니다.
+     */
+    private List<BookingResponseDTO> processBookingStreamWithBatchFlush(Stream<Booking> bookingStream) {
+        List<Booking> batch = new ArrayList<>(BATCH_FLUSH_SIZE);
+        List<BookingResponseDTO> result = new ArrayList<>();
+        Iterator<Booking> iterator = bookingStream.iterator();
+
+        while (iterator.hasNext()) {
+            batch.add(iterator.next());
+            if (batch.size() >= BATCH_FLUSH_SIZE) {
+                result.addAll(toBookingResponseDTOs(batch));
+                batch.forEach(entityManager::detach);
+                batch.clear();
+            }
+        }
+
+        if (!batch.isEmpty()) {
+            result.addAll(toBookingResponseDTOs(batch));
+            batch.forEach(entityManager::detach);
+        }
+
+        return result;
     }
 
     private BookingResponseDTO toBookingResponseDTO(Booking booking) {

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/BookingServiceTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/BookingServiceTest.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,6 +47,8 @@ import com.coDevs.cohiChat.member.entity.Member;
 import com.coDevs.cohiChat.timeslot.TimeSlotRepository;
 import com.coDevs.cohiChat.timeslot.entity.TimeSlot;
 
+import jakarta.persistence.EntityManager;
+
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class BookingServiceTest {
@@ -58,6 +61,9 @@ class BookingServiceTest {
     private static final String TEST_TOPIC = "프로젝트 상담";
     private static final String TEST_DESCRIPTION = "Spring Boot 프로젝트 관련 질문";
     private static final String TEST_GOOGLE_CALENDAR_ID = "test@group.calendar.google.com";
+
+    @Mock
+    private EntityManager entityManager;
 
     @Mock
     private BookingRepository bookingRepository;
@@ -324,8 +330,8 @@ class BookingServiceTest {
         given(timeSlot.getEndTime()).willReturn(LocalTime.of(11, 0));
         Booking booking1 = Booking.create(timeSlot, GUEST_ID, FUTURE_DATE, TEST_TOPIC, TEST_DESCRIPTION);
         Booking booking2 = Booking.create(timeSlot, GUEST_ID, FUTURE_DATE.plusDays(1), "토픽2", "설명2");
-        given(bookingRepository.findByGuestIdOrderByBookingDateDesc(GUEST_ID))
-            .willReturn(List.of(booking2, booking1));
+        given(bookingRepository.streamByGuestIdOrderByBookingDateDesc(GUEST_ID))
+            .willReturn(Stream.of(booking2, booking1));
 
         // when
         List<BookingResponseDTO> responses = bookingService.getBookingsByGuestId(GUEST_ID);
@@ -340,8 +346,8 @@ class BookingServiceTest {
     @DisplayName("성공: 게스트 예약이 없으면 빈 목록 반환")
     void getBookingsByGuestIdEmptyList() {
         // given
-        given(bookingRepository.findByGuestIdOrderByBookingDateDesc(GUEST_ID))
-            .willReturn(List.of());
+        given(bookingRepository.streamByGuestIdOrderByBookingDateDesc(GUEST_ID))
+            .willReturn(Stream.empty());
 
         // when
         List<BookingResponseDTO> responses = bookingService.getBookingsByGuestId(GUEST_ID);
@@ -359,8 +365,8 @@ class BookingServiceTest {
         given(timeSlot.getEndTime()).willReturn(LocalTime.of(11, 0));
         Booking booking1 = Booking.create(timeSlot, GUEST_ID, FUTURE_DATE, TEST_TOPIC, TEST_DESCRIPTION);
         Booking booking2 = Booking.create(timeSlot, GUEST_ID, FUTURE_DATE.plusDays(1), "토픽2", "설명2");
-        given(bookingRepository.findByHostIdOrderByBookingDateDesc(HOST_ID))
-            .willReturn(List.of(booking2, booking1));
+        given(bookingRepository.streamByHostIdOrderByBookingDateDesc(HOST_ID))
+            .willReturn(Stream.of(booking2, booking1));
 
         // when
         List<BookingResponseDTO> responses = bookingService.getBookingsByHostId(HOST_ID);
@@ -375,8 +381,8 @@ class BookingServiceTest {
     @DisplayName("성공: 호스트 예약이 없으면 빈 목록 반환")
     void getBookingsByHostIdEmptyList() {
         // given
-        given(bookingRepository.findByHostIdOrderByBookingDateDesc(HOST_ID))
-            .willReturn(List.of());
+        given(bookingRepository.streamByHostIdOrderByBookingDateDesc(HOST_ID))
+            .willReturn(Stream.empty());
 
         // when
         List<BookingResponseDTO> responses = bookingService.getBookingsByHostId(HOST_ID);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #165

---

## 📦 뭘 만들었나요? (What)

- `BookingRepository`에 `Stream<Booking>` 반환 메서드 추가
- `BookingService`에서 List 대신 Stream 기반 처리
- 100개 단위 배치 flush로 메모리 효율 개선 (`entityManager.clear()`)

---

## 왜 이렇게 만들었나요? (Why)

**기존 문제 (PR #150 코드리뷰 P3):**
- `List<Booking>`으로 전량 로드 후 스트리밍 → 메모리 비효율
- 매 아이템마다 `flush()` 호출 → I/O 오버헤드

**개선:**
- `Stream<Booking>` 순차 처리로 메모리 사용량 감소
- `@QueryHints(HINT_FETCH_SIZE = "100")`로 100개 단위 배치 조회
- `processBookingStreamWithBatchFlush()`로 100개마다 영속성 컨텍스트 정리

---

## 어떻게 테스트했나요? (Test)

- 컴파일 확인

---

## 참고사항 / 회고 메모 (Notes)

- 대용량 예약 데이터 조회 시 메모리 효율 개선 기대

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 예약 조회 및 처리 시 응답 속도 최적화
  * 시스템 메모리 효율성 개선으로 대량 데이터 처리 시 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->