### PR TITLE
refactor: #208 MemberControllerTest @MethodSource FQCN 제거

### DIFF
--- a/backend/src/test/java/com/coDevs/cohiChat/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/member/MemberControllerTest.java
@@ -94,7 +94,7 @@ class MemberControllerTest {
 		}
 
 		@ParameterizedTest
-		@MethodSource("com.coDevs.cohiChat.member.MemberControllerTest#usernameTestProvider")
+		@MethodSource("usernameTestProvider")
 		@DisplayName("아이디 검증 테스트")
 		void signupUsernameTest(String username, boolean shouldSucceed) throws Exception {
 			SignupRequestDTO dto = SignupRequestDTO.builder()
@@ -107,8 +107,29 @@ class MemberControllerTest {
 			performSignupTest(dto, shouldSucceed);
 		}
 
+		static Stream<Arguments> usernameTestProvider() {
+			return Stream.of(
+				Arguments.of(null, false),
+				Arguments.of("aaa", false),
+				Arguments.of("aaaa", true),
+				Arguments.of("a".repeat(12), true),
+				Arguments.of("a".repeat(13), false),
+
+				Arguments.of("test_user", true),
+				Arguments.of("test.user", true),
+				Arguments.of("test-user", true),
+				Arguments.of("test123", true),
+				Arguments.of("TEST", true),
+				Arguments.of("test@user", false),
+				Arguments.of("test user", false),
+				Arguments.of("test#user", false),
+				Arguments.of("테스트", false),
+				Arguments.of("test!user", false)
+			);
+		}
+
 		@ParameterizedTest
-		@MethodSource("com.coDevs.cohiChat.member.MemberControllerTest#passwordTestProvider")
+		@MethodSource("passwordTestProvider")
 		@DisplayName("비밀번호 검증 테스트")
 		void signupPasswordTest(String password, boolean shouldSucceed) throws Exception {
 			SignupRequestDTO dto = SignupRequestDTO.builder()
@@ -121,8 +142,29 @@ class MemberControllerTest {
 			performSignupTest(dto, shouldSucceed);
 		}
 
+		static Stream<Arguments> passwordTestProvider() {
+			return Stream.of(
+				Arguments.of(null, false),
+				Arguments.of("abcdefg", false),
+				Arguments.of("abcdefgh", true),
+				Arguments.of("a".repeat(20), true),
+				Arguments.of("a".repeat(21), false),
+
+				Arguments.of("pass_wrd", true),
+				Arguments.of("pass.wrd", true),
+				Arguments.of("pass-wrd", true),
+				Arguments.of("Pass1234", true),
+				Arguments.of("PASSWORD", true),
+				Arguments.of("pass@wrd", true),
+				Arguments.of("pass wrd", false),
+				Arguments.of("pass#wrd", true),
+				Arguments.of("비밀번호입니다abc", false),
+				Arguments.of("pass!wrd", true)
+			);
+		}
+
 		@ParameterizedTest
-		@MethodSource("com.coDevs.cohiChat.member.MemberControllerTest#displayNameTestProvider")
+		@MethodSource("displayNameTestProvider")
 		@DisplayName("닉네임 검증 테스트")
 		void signupDisplayNameTest(String displayName, boolean shouldSucceed) throws Exception {
 			SignupRequestDTO dto = SignupRequestDTO.builder()
@@ -135,8 +177,20 @@ class MemberControllerTest {
 			performSignupTest(dto, shouldSucceed);
 		}
 
+		static Stream<Arguments> displayNameTestProvider() {
+			return Stream.of(
+				Arguments.of(null, false),
+				Arguments.of("", false),
+				Arguments.of("  ", false),
+				Arguments.of("a", false),
+				Arguments.of("aa", true),
+				Arguments.of("a".repeat(20), true),
+				Arguments.of("a".repeat(21), false)
+			);
+		}
+
 		@ParameterizedTest
-		@MethodSource("com.coDevs.cohiChat.member.MemberControllerTest#emailTestProvider")
+		@MethodSource("emailTestProvider")
 		@DisplayName("이메일 검증 테스트")
 		void signupEmailTest(String email, boolean shouldSucceed) throws Exception {
 			SignupRequestDTO dto = SignupRequestDTO.builder()
@@ -147,6 +201,34 @@ class MemberControllerTest {
 				.build();
 
 			performSignupTest(dto, shouldSucceed);
+		}
+
+		static Stream<Arguments> emailTestProvider() {
+			return Stream.of(
+				// 유효한 이메일
+				Arguments.of("test@example.com", true),
+				Arguments.of("user.name@domain.co.kr", true),
+				Arguments.of("user+tag@example.org", true),
+				Arguments.of("user123@test.io", true),
+				Arguments.of("a.b.c@example.com", true),
+
+				// 무효한 이메일 - 형식 오류
+				Arguments.of(null, false),
+				Arguments.of("", false),
+				Arguments.of("test", false),
+				Arguments.of("test@", false),
+				Arguments.of("@test.com", false),
+				Arguments.of("test@.com", false),
+
+				// 무효한 이메일 - TLD 부족
+				Arguments.of("test@a", false),
+				Arguments.of("test@a.", false),
+				Arguments.of("a@b.c", false),
+
+				// 무효한 이메일 - 잘못된 문자
+				Arguments.of("test @example.com", false),
+				Arguments.of("test<>@example.com", false)
+			);
 		}
 	}
 
@@ -289,88 +371,6 @@ class MemberControllerTest {
 				.andExpect(jsonPath("$.data[1].username").value("host2"))
 				.andExpect(jsonPath("$.error").isEmpty());
 		}
-	}
-
-	static Stream<Arguments> usernameTestProvider() {
-		return Stream.of(
-			Arguments.of(null, false),
-			Arguments.of("aaa", false),
-			Arguments.of("aaaa", true),
-			Arguments.of("a".repeat(12), true),
-			Arguments.of("a".repeat(13), false),
-
-			Arguments.of("test_user", true),
-			Arguments.of("test.user", true),
-			Arguments.of("test-user", true),
-			Arguments.of("test123", true),
-			Arguments.of("TEST", true),
-			Arguments.of("test@user", false),
-			Arguments.of("test user", false),
-			Arguments.of("test#user", false),
-			Arguments.of("테스트", false),
-			Arguments.of("test!user", false)
-		);
-	}
-
-	static Stream<Arguments> passwordTestProvider() {
-		return Stream.of(
-			Arguments.of(null, false),
-			Arguments.of("abcdefg", false),
-			Arguments.of("abcdefgh", true),
-			Arguments.of("a".repeat(20), true),
-			Arguments.of("a".repeat(21), false),
-
-			Arguments.of("pass_wrd", true),
-			Arguments.of("pass.wrd", true),
-			Arguments.of("pass-wrd", true),
-			Arguments.of("Pass1234", true),
-			Arguments.of("PASSWORD", true),
-			Arguments.of("pass@wrd", true),
-			Arguments.of("pass wrd", false),
-			Arguments.of("pass#wrd", true),
-			Arguments.of("비밀번호입니다abc", false),
-			Arguments.of("pass!wrd", true)
-		);
-	}
-
-	static Stream<Arguments> displayNameTestProvider() {
-		return Stream.of(
-			Arguments.of(null, false),
-			Arguments.of("", false),
-			Arguments.of("  ", false),
-			Arguments.of("a", false),
-			Arguments.of("aa", true),
-			Arguments.of("a".repeat(20), true),
-			Arguments.of("a".repeat(21), false)
-		);
-	}
-
-	static Stream<Arguments> emailTestProvider() {
-		return Stream.of(
-			// 유효한 이메일
-			Arguments.of("test@example.com", true),
-			Arguments.of("user.name@domain.co.kr", true),
-			Arguments.of("user+tag@example.org", true),
-			Arguments.of("user123@test.io", true),
-			Arguments.of("a.b.c@example.com", true),
-
-			// 무효한 이메일 - 형식 오류
-			Arguments.of(null, false),
-			Arguments.of("", false),
-			Arguments.of("test", false),
-			Arguments.of("test@", false),
-			Arguments.of("@test.com", false),
-			Arguments.of("test@.com", false),
-
-			// 무효한 이메일 - TLD 부족
-			Arguments.of("test@a", false),
-			Arguments.of("test@a.", false),
-			Arguments.of("a@b.c", false),
-
-			// 무효한 이메일 - 잘못된 문자
-			Arguments.of("test @example.com", false),
-			Arguments.of("test<>@example.com", false)
-		);
 	}
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #208

---

## 📦 뭘 만들었나요? (What)

- `MemberControllerTest` 내 `@MethodSource` 어노테이션에서 FQCN(전체 클래스 경로) 하드코딩 제거
- `@Nested` 클래스에서 enclosing class의 static method를 참조하도록 개선

---

## 왜 이렇게 만들었나요? (Why)

**기존 문제 (PR #156 코드리뷰 P4):**
```java
@MethodSource("com.coDevs.cohiChat.member.MemberControllerTest#usernameTestProvider")
```
- 패키지 리팩토링 시 깨짐
- 유지보수성 저하

**개선:**
- FQCN 없이 참조 가능한 구조로 변경

---

## 어떻게 테스트했나요? (Test)

- 테스트 실행 확인

---

## 참고사항 / 회고 메모 (Notes)

- N/A