### PR TITLE
fix: #263 StepIndicator 모바일 오버플로우 반응형 수정

### DIFF
--- a/frontend/src/features/host/components/register/StepIndicator.tsx
+++ b/frontend/src/features/host/components/register/StepIndicator.tsx
@@ -1,3 +1,5 @@
+import { cn } from '~/libs/cn';
+
 interface StepIndicatorProps {
     currentStep: number;
     totalSteps: number;
@@ -5,7 +7,7 @@ interface StepIndicatorProps {
 
 export default function StepIndicator({ currentStep, totalSteps }: StepIndicatorProps) {
     return (
-        <div className="flex items-center justify-center gap-0">
+        <div data-testid="step-indicator" className="flex items-center justify-center gap-0">
             {Array.from({ length: totalSteps }, (_, i) => {
                 const step = i + 1;
                 const isActive = step === currentStep;
@@ -15,20 +17,19 @@ export default function StepIndicator({ currentStep, totalSteps }: StepIndicator
                     <div key={step} className="flex items-center">
                         {/* Step circle */}
                         <div
-                            className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold transition-colors ${
-                                isActive
+                            className={cn(
+                                'w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold transition-colors',
+                                isActive || isCompleted
                                     ? 'bg-[var(--cohi-primary)] text-white'
-                                    : isCompleted
-                                        ? 'bg-[var(--cohi-primary)] text-white'
-                                        : 'bg-[var(--cohi-bg-warm)] text-[var(--cohi-text-dark)]'
-                            }`}
+                                    : 'bg-[var(--cohi-bg-warm)] text-[var(--cohi-text-dark)]'
+                            )}
                         >
                             {isCompleted ? '✓' : step}
                         </div>
 
                         {/* Label for active step */}
                         {isActive && (
-                            <span className="ml-2 text-sm font-semibold text-[var(--cohi-text-dark)]">
+                            <span className="ml-2 text-sm font-semibold text-[var(--cohi-text-dark)] hidden sm:inline">
                                 호스트 등록 ({currentStep}/{totalSteps})
                             </span>
                         )}
@@ -36,9 +37,10 @@ export default function StepIndicator({ currentStep, totalSteps }: StepIndicator
                         {/* Connector line */}
                         {step < totalSteps && (
                             <div
-                                className={`w-12 h-0.5 mx-2 ${
+                                className={cn(
+                                    'w-6 sm:w-12 h-0.5 mx-1 sm:mx-2',
                                     isCompleted ? 'bg-[var(--cohi-primary)]' : 'bg-[var(--cohi-bg-warm)]'
-                                }`}
+                                )}
                             />
                         )}
                     </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #263

---

## 📦 뭘 만들었나요? (What)

- StepIndicator 컴포넌트 모바일 반응형 적용:
  - 텍스트 라벨("호스트 등록 (1/3)"): `hidden sm:inline` (모바일에서 숨김)
  - Connector line: `w-6 sm:w-12`, `mx-1 sm:mx-2` (모바일에서 축소)

---

## 왜 이렇게 만들었나요? (Why)

**문제점:**
- 모바일(400px) 뷰포트에서 StepIndicator가 423.5px로 렌더링
- 가로 스크롤 발생으로 UX 저하
<img width="440" height="138" alt="image" src="https://github.com/user-attachments/assets/fd5f2583-60f5-49af-b9e0-a31cf4bf3c2d" />

**원인:**
- 고정 너비 connector line(`w-12`, 48px)
- 텍스트 라벨 오버플로우

**해결:**
- 640px 미만: 텍스트 숨김, connector 24px
- 640px 이상: 텍스트 표시, connector 48px

---

## 어떻게 테스트했나요? (Test)

- 모바일 뷰포트(400px)에서 가로 스크롤 없음 확인 필요

---

## 참고사항 / 회고 메모 (Notes)

- Tailwind 반응형 breakpoint `sm` (640px) 기준 적용