### PR TITLE
fix: MemberService RandomStringGenerator 제거 및 닉네임 username 폴백 처리

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -77,9 +77,11 @@ dependencies {
     testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'org.apache.commons:commons-text:1.15.0'
-
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // SQLite (local dev)
+    runtimeOnly 'org.xerial:sqlite-jdbc:3.45.2.0'
+    runtimeOnly 'org.hibernate.orm:hibernate-community-dialects'
 
     // Google Calendar API
     implementation 'com.google.api-client:google-api-client:2.7.0'

--- a/backend/src/main/java/com/coDevs/cohiChat/member/MemberService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/MemberService.java
@@ -38,7 +38,6 @@ import com.coDevs.cohiChat.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.text.RandomStringGenerator;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -65,7 +64,7 @@ public class MemberService {
 		validateDuplicate(request.getUsername(), request.getEmail());
 
 		String displayName = (request.getDisplayName() == null || request.getDisplayName().isBlank())
-			? generateDefaultDisplayName() : request.getDisplayName();
+			? request.getUsername() : request.getDisplayName();
 
 		Role role = (request.getRole() != null) ? request.getRole() : Role.GUEST;
 
@@ -96,15 +95,6 @@ public class MemberService {
 		if (memberRepository.existsByEmail(email.toLowerCase())) {
 			throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
 		}
-	}
-
-	private String generateDefaultDisplayName() {
-
-		return new RandomStringGenerator.Builder()
-			.withinRange('0', 'z')
-			.filteredBy(Character::isLetterOrDigit)
-			.build()
-			.generate(8);
 	}
 
 	@Transactional


### PR DESCRIPTION
## 🔗 관련 이슈
- 해당 없음 (hotfix)

---

## 📦 뭘 만들었나요? (What)

- `MemberService`에서 `RandomStringGenerator` (Apache Commons Text) 제거
- 닉네임(`displayName`) 미입력 시 랜덤 문자열 대신 `username`으로 폴백
- `commons-text` 의존성 제거 (`build.gradle`)
- SQLite 드라이버 추가 (`build.gradle`, 로컬 dev 환경용)

---

## 왜 이렇게 만들었나요? (Why)

닉네임 랜덤 생성 로직이 프론트엔드로 이관됨에 따라 백엔드의 `generateDefaultDisplayName()` 메서드와 `commons-text` 의존성이 불필요해졌습니다.

기본값은 `username`을 그대로 사용하는 방식으로 단순화했습니다.

---

## 어떻게 테스트했나요? (Test)

- 로컬에서 `dev` 프로파일 (SQLite) 기동 후 회원가입/로그인 정상 동작 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. `displayName` 없이 회원가입 요청 → `username`이 닉네임으로 저장됨
2. `displayName` 있이 회원가입 요청 → 입력한 닉네임으로 저장됨
3. 로그인 정상 동작 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

`commons-text` 의존성 복구 커밋(6521e6c)이 main에 머지되어 있어, 해당 내용을 다시 제거하는 핫픽스입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **향상 사항**
  * 회원가입 시 표시명이 지정되지 않은 경우 사용자명을 기본값으로 사용하도록 변경했습니다.

* **Chores**
  * 라이브러리 의존성을 업데이트했습니다. 데이터베이스 지원 및 ORM 관련 라이브러리를 추가하고 불필요한 의존성을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->