### PR TITLE
feat: #377 Spring Boot DevTools 추가 (Backend Hot Reload)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:secretsmanager'
 
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #377

---

## 📦 뭘 만들었나요? (What)

`spring-boot-devtools` 의존성을 `developmentOnly`로 추가하여 백엔드 개발 시 Hot Reload(자동 재시작)를 지원한다.

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

현재 백엔드 코드 수정 시 매번 수동으로 서버를 재시작해야 해서 개발 생산성이 떨어진다.
`developmentOnly`로 추가하면 개발 환경에서만 동작하고, 프로덕션 jar 패키징 시 자동 제외되므로 안전하다.

---

## 어떻게 테스트했나요? (Test)

로컬에서 `./gradlew bootRun` 실행 후 코드 변경 시 자동 재시작 확인 필요.

<details>
<summary>테스트 시나리오 (선택)</summary>

1. `./gradlew bootRun` 으로 서버 실행
2. Java 소스 코드 수정 후 저장
3. 콘솔에서 자동 재시작 로그 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- DevTools는 두 개의 클래스로더를 사용하여 일반 재시작보다 빠르게 동작
- IDE에서 자동 빌드 설정이 필요할 수 있음 (IntelliJ: Build > Build project automatically)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 환경용 빌드 도구 의존성을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->