### PR TITLE
feat: #359 FE 배포를 S3 + CloudFront 방식으로 변경

### DIFF
--- a/.github/workflows/client-deploy-prod.yml
+++ b/.github/workflows/client-deploy-prod.yml
@@ -16,6 +16,7 @@ concurrency:
 env:
   AWS_REGION: ap-northeast-2
   S3_FRONTEND_DIST: s3://cohi-chat-config/frontend/dist
+  CLOUDFRONT_DISTRIBUTION_ID: E2TSEBMG1RADEW
 
 jobs:
   build-and-deploy:
@@ -60,53 +61,8 @@ jobs:
         run: |
           aws s3 sync frontend/dist ${{ env.S3_FRONTEND_DIST }} --delete
 
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@v1.2.0
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          S3_FRONTEND_DIST: ${{ env.S3_FRONTEND_DIST }}
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          envs: AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_REGION,S3_FRONTEND_DIST
-          command_timeout: 40m
-          script: |
-            export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-            export AWS_DEFAULT_REGION=$AWS_REGION
-            export S3_FRONTEND_DIST=$S3_FRONTEND_DIST
-
-            if [ -z "$S3_FRONTEND_DIST" ]; then
-              echo "S3_FRONTEND_DIST is empty"
-              exit 1
-            fi
-
-            # 공통 설정 스크립트 로드 및 실행
-            source ~/cohi-chat/scripts/ec2-deploy-common.sh 2>/dev/null || {
-              # 스크립트가 없으면 먼저 저장소 동기화
-              set -euo pipefail
-              if [ ! -d ~/cohi-chat ]; then
-                git clone https://github.com/${{ github.repository }}.git ~/cohi-chat
-              fi
-              cd ~/cohi-chat
-              git fetch origin
-              git reset --hard origin/${{ github.ref_name }}
-              source ~/cohi-chat/scripts/ec2-deploy-common.sh
-            }
-
-            run_common_setup "${{ github.repository }}" "${{ github.ref_name }}"
-
-            # Frontend 배포
-            mkdir -p frontend/dist
-            aws s3 sync "$S3_FRONTEND_DIST" ~/cohi-chat/frontend/dist --delete
-            docker-compose -f docker-compose.prod.yml up -d frontend
-
-            echo "Waiting for frontend to start..."
-            sleep 10
-
-            docker-compose -f docker-compose.prod.yml ps
-            docker-compose -f docker-compose.prod.yml logs --tail=50 frontend
-            log_deploy_success
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #359

---

## 📦 뭘 만들었나요? (What)

FE 배포 프로세스를 EC2 Docker 방식에서 S3 + CloudFront 방식으로 변경

- EC2 SSH 배포 로직 제거
- CloudFront 캐시 무효화(Invalidation) 추가
- CloudFront Distribution ID 환경변수 추가

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

기존: S3 → EC2 다운로드 → Docker nginx 서빙
변경: S3 → CloudFront CDN 직접 서빙

- CDN 캐싱으로 응답 속도 향상
- EC2 의존성 제거로 배포 파이프라인 단순화
- 정적 파일 서빙에 EC2 리소스 불필요

---

## 어떻게 테스트했나요? (Test)

- CloudFront 배포 생성 및 설정 완료
- https://d2xiifwvsk5qy3.cloudfront.net 접속 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. main 머지 후 workflow 실행 확인
2. CloudFront URL로 FE 접속 테스트

</details>

---

## 참고사항 / 회고 메모 (Notes)

- CloudFront Distribution ID: `E2TSEBMG1RADEW`
- CloudFront 도메인: `d2xiifwvsk5qy3.cloudfront.net`
- 커스텀 도메인 연결은 별도 이슈로 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 배포 워크플로우 개선 - CloudFront 캐시 무효화 기능 추가 및 배포 프로세스 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->