### PR TITLE
fix: CloudFront 반영 누락 방지용 FE 배포 캐시 정책 보강

### DIFF
--- a/.github/workflows/client-deploy-prod.yml
+++ b/.github/workflows/client-deploy-prod.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   AWS_REGION: ap-northeast-2
+  S3_BUCKET: cohi-chat-config
   S3_FRONTEND_DIST: s3://cohi-chat-config/frontend/dist
 
 jobs:
@@ -59,6 +60,16 @@ jobs:
       - name: Upload frontend dist to S3
         run: |
           aws s3 sync frontend/dist ${{ env.S3_FRONTEND_DIST }} --delete
+          # Keep bucket root in sync as well, so CloudFront works
+          # whether OriginPath is empty or /frontend/dist.
+          aws s3 sync frontend/dist s3://${{ env.S3_BUCKET }}
+          # Prevent stale index.html in browser cache from referencing old hashed assets.
+          aws s3 cp frontend/dist/index.html ${{ env.S3_FRONTEND_DIST }}/index.html \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html; charset=utf-8"
+          aws s3 cp frontend/dist/index.html s3://${{ env.S3_BUCKET }}/index.html \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html; charset=utf-8"
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
## 변경 사항
- FE 빌드 산출물을 s3://cohi-chat-config/frontend/dist에 업로드 유지
- 동일 산출물을 버킷 루트(s3://cohi-chat-config)에도 동기화
- index.html을 두 경로 모두 Cache-Control: no-cache, no-store, must-revalidate로 재업로드
- CloudFront invalidation(/*)은 기존처럼 유지

## 배경
CloudFront OriginPath 설정 차이(비어 있음 vs /frontend/dist)와 index 캐시로 인해 새 FE가 반영되지 않거나 해시 파일 404가 발생할 수 있어, 양쪽 경로 대응 + index 무캐시로 안정화했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **배포 개선**
  * S3 배포 워크플로우 최적화를 통한 프론트엔드 배포 안정성 강화
  * 캐시 제어 메커니즘 개선으로 사용자가 항상 최신 버전의 애플리케이션 다운로드 보장
  * 인덱스 페이지 캐싱 정책 업데이트로 구식 에셋 참조 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->