### PR TITLE
feat: #355 /my-bookings 페이지 로그인 인증 가드 추가

### DIFF
--- a/frontend/src/pages/calendar/MyBookingsGuarded.test.tsx
+++ b/frontend/src/pages/calendar/MyBookingsGuarded.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const navigateMock = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+    useNavigate: () => navigateMock,
+    useSearch: () => ({ page: 1, pageSize: 10 }),
+    Link: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+        React.createElement('a', props, children),
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock('~/features/member', () => ({
+    useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('./MyBookings', () => ({
+    default: () => React.createElement('div', { 'data-testid': 'my-bookings-page' }, '내 예약 목록'),
+}));
+
+import MyBookingsGuarded from './MyBookingsGuarded';
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+
+    return ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('MyBookingsGuarded', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('로딩 중일 때 로딩 메시지를 표시한다', () => {
+        mockUseAuth.mockReturnValue({
+            isAuthenticated: false,
+            isLoading: true,
+        });
+
+        render(<MyBookingsGuarded />, { wrapper: createWrapper() });
+        expect(screen.getByText('확인 중...')).toBeInTheDocument();
+    });
+
+    it('미인증 사용자는 /login으로 리다이렉트된다', async () => {
+        mockUseAuth.mockReturnValue({
+            isAuthenticated: false,
+            isLoading: false,
+        });
+
+        render(<MyBookingsGuarded />, { wrapper: createWrapper() });
+
+        await waitFor(() => {
+            expect(navigateMock).toHaveBeenCalledWith({ to: '/login' });
+        });
+    });
+
+    it('인증된 사용자에게 MyBookings 컴포넌트를 렌더링한다', () => {
+        mockUseAuth.mockReturnValue({
+            isAuthenticated: true,
+            isLoading: false,
+        });
+
+        render(<MyBookingsGuarded />, { wrapper: createWrapper() });
+        expect(screen.getByTestId('my-bookings-page')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/calendar/MyBookingsGuarded.tsx
+++ b/frontend/src/pages/calendar/MyBookingsGuarded.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { useAuth } from '~/features/member';
+import MyBookings from './MyBookings';
+
+export default function MyBookingsGuarded() {
+    const { isAuthenticated, isLoading } = useAuth();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (isLoading) return;
+        if (!isAuthenticated) {
+            navigate({ to: '/login' });
+        }
+    }, [isAuthenticated, isLoading, navigate]);
+
+    if (isLoading) {
+        return (
+            <div className="w-full min-h-screen bg-[var(--cohi-bg-light)] flex items-center justify-center">
+                <p className="text-gray-500">확인 중...</p>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) return null;
+
+    return <MyBookings />;
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -9,7 +9,7 @@ import Calendar from '../pages/calendar/Calendar'
 import { LoginForm, SignupForm } from '~/features/member'
 import Home from '~/pages/main/Home'
 import OAuthCallbackPage from '~/pages/oauth/OAuthCallbackPage'
-import MyBookings from '~/pages/calendar/MyBookings'
+import MyBookingsGuarded from '~/pages/calendar/MyBookingsGuarded'
 import Booking from '~/pages/calendar/Booking'
 import HostRegisterGuarded from '~/pages/host/HostRegisterGuarded'
 import TimeSlotSettingsGuarded from '~/pages/host/TimeSlotSettingsGuarded'
@@ -61,7 +61,7 @@ const homeRoute = createRoute({
 const myBookingsRoute = createRoute({
     getParentRoute: () => RootRoute,
     path: '/my-bookings',
-    component: MyBookings,
+    component: MyBookingsGuarded,
     validateSearch: z.object({
         page: z.number().min(1).optional().default(() => 1),
         pageSize: z.number().min(1).optional().default(() => 10),


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #355

---

## 📦 뭘 만들었나요? (What)

/my-bookings 페이지에 로그인 인증 가드를 추가하여 비로그인 사용자의 접근을 차단합니다.

- `MyBookingsGuarded` 컴포넌트 생성 (기존 SettingsGuarded 패턴 동일)
- 비로그인 시 `/login`으로 리다이렉트
- 라우트 정의에서 `MyBookings` → `MyBookingsGuarded`로 교체

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

공통 AuthGuard 컴포넌트를 만들 수도 있었지만, 기존 프로젝트의 `*Guarded.tsx` 패턴(SettingsGuarded, HostRegisterGuarded 등)과 일관성을 유지하기 위해 동일한 패턴을 적용했습니다. 공통화는 #376 이슈에서 별도로 진행될 예정입니다.

---

## 어떻게 테스트했나요? (Test)

Vitest 단위 테스트 3개 작성 및 통과:

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 로딩 중일 때 로딩 메시지("확인 중...") 표시
2. 미인증 사용자는 /login으로 리다이렉트
3. 인증된 사용자에게 MyBookings 컴포넌트 정상 렌더링

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 기존 Guard 패턴과 100% 동일한 구조로 작성하여 리뷰 부담 최소화
- 로그인 후 원래 페이지로 돌아오는 redirect 기능은 별도 이슈로 개선 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 페이지에 인증 보호 기능 추가
  * 미인증 사용자를 자동으로 로그인 페이지로 리다이렉트
  * 인증 상태 확인 중에 로딩 표시 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->