### PR TITLE
refactor: #219 호스트 프로필 권한 정책 및 검증 테스트 보강

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/host/HostController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/host/HostController.java
@@ -42,11 +42,14 @@ public class HostController {
 	@ApiResponses({
 		@ApiResponse(responseCode = "201", description = "호스트 등록 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요"),
-		@ApiResponse(responseCode = "403", description = "권한 없음"),
+		@ApiResponse(responseCode = "403", description = "권한 없음 (GUEST만 등록 가능)"),
 		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
 		@ApiResponse(responseCode = "409", description = "이미 호스트로 등록됨")
 	})
 	@PostMapping("/v1/register")
+	// hasRole('GUEST') 대신 isAuthenticated() 유지:
+	// promoteToHost()에서 이미 HOST인 경우 409(ALREADY_HOST)를 반환해야 하므로
+	// 역할 검증은 도메인 레이어에 위임한다.
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponseDTO<HostProfileResponseDTO>> register(Principal principal) {
 		HostProfileResponseDTO response = hostService.registerAsHost(principal.getName());

--- a/backend/src/test/java/com/coDevs/cohiChat/host/HostControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/host/HostControllerTest.java
@@ -155,6 +155,18 @@ class HostControllerTest {
 		}
 
 		@Test
+		@DisplayName("displayName이 50자 초과이면 400 반환")
+		void updateProfileDisplayNameExceeds50Characters() throws Exception {
+			String longDisplayName = "a".repeat(51);
+
+			mockMvc.perform(put("/hosts/v1/me")
+					.principal(() -> "testuser")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"displayName\": \"" + longDisplayName + "\"}"))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
 		@DisplayName("GUEST가 프로필 수정 시 403 반환")
 		void guestCannotUpdateProfile() throws Exception {
 			when(hostService.updateHostProfile(anyString(), anyString()))


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #219

---

## 📦 뭘 만들었나요? (What)

호스트 프로필 권한 정책을 정리하고 검증 테스트를 보강했습니다.

- `HostController.register` 역할 정책 결정 사유 문서화 (isAuthenticated 유지)
- Swagger 403 응답 설명을 "GUEST만 등록 가능"으로 구체화
- `HostControllerTest`에 displayName 50자 초과 실패(400) 테스트 추가

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

`hasRole('GUEST')`를 컨트롤러에 적용하면 이미 HOST인 사용자의 재등록 시도 시 Spring Security가 403을 먼저 반환하여 기존 409(ALREADY_HOST) 응답이 깨집니다. 따라서 역할 검증은 `Member.promoteToHost()` 도메인 레이어에 위임하고, 컨트롤러에는 결정 사유를 주석으로 문서화했습니다.

---

## 어떻게 테스트했나요? (Test)

`./gradlew test` 전체 테스트 스위트 통과 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. displayName 50자 초과 시 400 Bad Request 반환
2. 기존 테스트 (등록 성공 201, 재등록 409, GUEST 접근 403) 모두 통과

</details>

---

## 참고사항 / 회고 메모 (Notes)

- `@PreAuthorize("isAuthenticated()")` 유지 결정은 도메인 로직의 세분화된 에러 응답을 보존하기 위한 의도적 선택입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서 개선**
  * 호스트 등록 엔드포인트의 API 문서를 업데이트하여 접근 권한 제한 사항을 명확히 했습니다.

* **테스트**
  * 프로필 표시 이름 길이 검증(최대 50자)을 위한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->