### PR TITLE
fix: #383 호스트 대시보드 시간대1 삭제/수정 불가 수정

### DIFF
--- a/frontend/src/features/host/components/timeslot/TimeSlotForm.tsx
+++ b/frontend/src/features/host/components/timeslot/TimeSlotForm.tsx
@@ -93,7 +93,6 @@ export default function TimeSlotForm({ entries, onChange, onSave, onDelete, isPe
     };
 
     const removeEntry = (index: number) => {
-        if (entries.length <= 1) return;
         // 삭제된 항목 이후 인덱스를 당겨서 savedDatesRef 재구성
         const newSavedDates: Record<number, { startDate: string; endDate: string }> = {};
         Object.entries(savedDatesRef.current).forEach(([key, value]) => {
@@ -105,7 +104,7 @@ export default function TimeSlotForm({ entries, onChange, onSave, onDelete, isPe
         savedDatesRef.current = newSavedDates;
         const updated = entries.filter((_, i) => i !== index);
         onChange(updated);
-        if (expandedIndex >= updated.length) setExpandedIndex(updated.length - 1);
+        setExpandedIndex(updated.length > 0 && expandedIndex >= updated.length ? updated.length - 1 : -1);
     };
 
     return (
@@ -125,7 +124,7 @@ export default function TimeSlotForm({ entries, onChange, onSave, onDelete, isPe
                         <div
                             data-testid="entry-header"
                             className="flex justify-between items-center cursor-pointer"
-                            onClick={() => setExpandedIndex(index)}
+                            onClick={() => setExpandedIndex(expandedIndex === index ? -1 : index)}
                         >
                             <div className="flex items-center gap-2">
                                 <span className="text-sm font-medium text-[var(--cohi-text-dark)]">
@@ -147,7 +146,7 @@ export default function TimeSlotForm({ entries, onChange, onSave, onDelete, isPe
                                 >
                                     {deletingId === entry.existingId ? '삭제 중...' : '삭제'}
                                 </button>
-                            ) : entries.length > 1 && !entry.existingId ? (
+                            ) : !entry.existingId ? (
                                 <button
                                     type="button"
                                     onClick={(e) => { e.stopPropagation(); removeEntry(index); }}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #383

## 📦 뭘 고쳤나요?

`TimeSlotForm.tsx`의 시간대 헤더 토글 및 단일 항목 삭제 로직 수정

### 버그 원인

`expandedIndex`가 `0`으로 초기화되어 시간대1은 항상 열린 상태였고, 헤더 클릭 시 `setExpandedIndex(0)` → 이미 0이므로 아무 변화 없음. 즉, 시간대1은 **닫을 수 없는 상태**였음.

또한 새 항목이 1개뿐일 때 삭제 버튼이 표시되지 않아 예시 항목을 지울 수 없었음.

## 🔧 변경 내용

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 헤더 클릭 | `setExpandedIndex(index)` (토글 없음) | `expandedIndex === index ? -1 : index` (토글) |
| 단일 새 항목 삭제 버튼 | `entries.length > 1` 조건으로 숨김 | 항목 수 무관하게 표시 |
| 마지막 항목 삭제 후 상태 | `entries.length <= 1`이면 early return | 삭제 허용 후 `expandedIndex = -1` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

https://github.com/user-attachments/assets/170a4c61-1c3b-4eb8-bd3e-1cdacb615a84


## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 시간대 항목 제거 기능 개선: 마지막 항목도 삭제 가능하도록 변경
  * 항목 삭제 후 확장 상태 더욱 안정적으로 관리
  * 헤더 클릭으로 항목 확장/축소 토글 가능
  * 삭제 버튼 표시 범위 확대: 신규 항목에서만 표시되던 것을 모든 미저장 항목에서 표시하도록 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->