### PR TITLE
fix: #387 client-deploy-prod 워크플로우 YAML 파싱 오류 수정

### DIFF
--- a/.github/workflows/client-deploy-prod.yml
+++ b/.github/workflows/client-deploy-prod.yml
@@ -73,20 +73,15 @@ jobs:
             --cache-control "no-cache, no-store, must-revalidate" \
             --content-type "text/html; charset=utf-8"
 
-      - name: Invalidate CloudFront cache
+      - name: Invalidate CloudFront cache and wait
         run: |
-          aws cloudfront create-invalidation \
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
             --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/*"
-        - name: Wait for CloudFront invalidation
-          run: |
-            INVALIDATION_ID=$(aws cloudfront create-invalidation \
-              --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
-              --paths "/*" \
-              --query 'Invalidation.Id' --output text)
-            aws cloudfront wait invalidation-completed \
-              --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
-              --id "$INVALIDATION_ID"
+            --paths "/*" \
+            --query 'Invalidation.Id' --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --id "$INVALIDATION_ID"
       - name: Verify public domain serves latest frontend assets
         run: |
           EXPECTED_JS=$(grep -o 'assets/index-[^"]*\.js' frontend/dist/index.html | head -1)


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #387 의 후속 수정 (워크플로우 파싱 실패)

---

## 📦 뭘 만들었나요? (What)
- `client-deploy-prod.yml`의 YAML 들여쓰기 오류를 수정
- 중복 CloudFront invalidation 생성을 단일 step으로 통합

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

`Wait for CloudFront invalidation` step이 `Invalidate CloudFront cache` step 내부에 중첩되어 YAML 파싱 자체가 실패했습니다.
- 들여쓰기를 steps 레벨로 교정
- 기존 `Invalidate CloudFront cache` step과 `Wait for CloudFront invalidation` step이 각각 invalidation을 생성하여 중복이었으므로, 생성+대기를 하나의 step으로 통합

---

## 어떻게 테스트했나요? (Test)
- YAML lint로 문법 유효성 확인
- 워크플로우 파일 diff로 들여쓰기 교정 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 수정된 워크플로우가 GitHub Actions에서 정상 파싱되는지 확인
2. CloudFront invalidation이 1회만 생성되고 완료 대기 후 검증 step이 실행되는지 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)
- Actions run https://github.com/CheHyeonYeong/cohi-chat/actions/runs/22713972158 에서 workflow file issue로 실패한 건의 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CloudFront 배포 워크플로우 단계를 최적화하여 효율성을 개선했습니다. 이제 무효화 작업과 완료 대기 프로세스가 하나의 단계로 통합되어 배포 속도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->