### PR TITLE
fix: #401 텍스트 선택 영역 배경색 브랜드 컬러 적용

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,7 +29,6 @@
 
 ::selection {
   background: rgba(139, 105, 20, 0.225);
-  color: var(--cohi-text-dark);
 }
 
 body {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #401

---

## 📦 뭘 만들었나요? (What)

텍스트 드래그(선택) 시 배경색을 브라우저 기본 파란색 → cohiChat 브랜드 컬러(`rgba(139, 105, 20, 0.15)`)로 변경

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- primary 원색(`#8B6914`)을 그대로 쓰면 너무 강해서, 15% 투명도로 설정
- 기존 timeslot에서 `rgba(139, 105, 20, 0.2~0.4)` 패턴을 사용하고 있어 일관성 유지
- 텍스트 색상은 `--cohi-text-dark`로 유지하여 가독성 확보

---

## 어떻게 테스트했나요? (Test)

로컬에서 텍스트 드래그하여 선택 배경색 육안 확인

---

## 참고사항 / 회고 메모 (Notes)

N/A

## 스크린샷

### Before

<img width="1780" height="1479" alt="스크린샷 2026-03-06 17 23 59" src="https://github.com/user-attachments/assets/43b34c8a-a9a7-4480-aa47-a9600ec46ace" />
<img width="1780" height="1479" alt="스크린샷 2026-03-06 17 25 47" src="https://github.com/user-attachments/assets/296abdae-f5b1-4009-bd2c-e4811d45e7f4" />

### After

<img width="1780" height="1479" alt="스크린샷 2026-03-06 17 34 21" src="https://github.com/user-attachments/assets/69e4ade0-63e0-4c8b-b449-312094e274c2" />
<img width="1780" height="1479" alt="스크린샷 2026-03-06 17 32 41" src="https://github.com/user-attachments/assets/f06cfd19-bed2-4c91-adf4-d16639c604f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
* 텍스트 선택 시 시각 효과를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->