### PR TITLE
hotfix: remove token hash from refresh reuse warning log

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/member/MemberService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/MemberService.java
@@ -295,7 +295,6 @@ public class MemberService {
 			}
 
 			// 구 RT가 아닌 토큰이거나 grace window 초과 → 탈취로 간주하여 전체 세션 무효화
-			log.warn("리프레시 토큰 재사용 감지 - 세션 무효화 처리: username={}, tokenHash={}", verifiedUsername, tokenHash);
 			refreshTokenRepository.deleteById(verifiedUsername);
 			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}


### PR DESCRIPTION
## 변경 사항
- `MemberService`에서 refresh token 재사용 감지 경고 로그의 `tokenHash` 출력 1줄 제거

## 배경
- 로그에 토큰 해시 전체값이 남는 보안 리스크 제거 목적

## 검증
- 코드 변경 1줄 삭제(diff 최소화)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 내부 코드 유지보수 및 최적화를 수행했습니다. 사용자 경험에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->