### PR TITLE
refactor: #396 GoogleCalendarSetup SVG 아이콘 분리

### DIFF
--- a/frontend/src/components/icons/CalendarIcon.tsx
+++ b/frontend/src/components/icons/CalendarIcon.tsx
@@ -1,0 +1,15 @@
+interface IconProps {
+    className?: string;
+}
+
+export default function CalendarIcon({ className = '' }: IconProps) {
+    return (
+        <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" strokeWidth="2" />
+            <path d="M3 10H21" stroke="currentColor" strokeWidth="2" />
+            <path d="M8 2V6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            <path d="M16 2V6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            <text x="12" y="18" textAnchor="middle" fill="currentColor" fontSize="7" fontWeight="bold">21</text>
+        </svg>
+    );
+}

--- a/frontend/src/components/icons/CheckIcon.tsx
+++ b/frontend/src/components/icons/CheckIcon.tsx
@@ -1,0 +1,11 @@
+interface IconProps {
+    className?: string;
+}
+
+export default function CheckIcon({ className = '' }: IconProps) {
+    return (
+        <svg className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3 8L6.5 11.5L13 4.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+    );
+}

--- a/frontend/src/components/icons/CopyIcon.tsx
+++ b/frontend/src/components/icons/CopyIcon.tsx
@@ -1,0 +1,12 @@
+interface IconProps {
+    className?: string;
+}
+
+export default function CopyIcon({ className = '' }: IconProps) {
+    return (
+        <svg className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="5" y="5" width="9" height="9" rx="1" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M3 11V3C3 2.44772 3.44772 2 4 2H12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+    );
+}

--- a/frontend/src/components/icons/ExternalLinkIcon.tsx
+++ b/frontend/src/components/icons/ExternalLinkIcon.tsx
@@ -1,0 +1,13 @@
+interface IconProps {
+    className?: string;
+}
+
+export default function ExternalLinkIcon({ className = '' }: IconProps) {
+    return (
+        <svg className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 3H3V13H13V10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M9 2H14V7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M14 2L7 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+    );
+}

--- a/frontend/src/components/icons/index.ts
+++ b/frontend/src/components/icons/index.ts
@@ -1,0 +1,5 @@
+export { default as CoffeeCupIcon } from './CoffeeCupIcon';
+export { default as CalendarIcon } from './CalendarIcon';
+export { default as ExternalLinkIcon } from './ExternalLinkIcon';
+export { default as CopyIcon } from './CopyIcon';
+export { default as CheckIcon } from './CheckIcon';

--- a/frontend/src/features/host/components/GoogleCalendarSetup.tsx
+++ b/frontend/src/features/host/components/GoogleCalendarSetup.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Button from '~/components/button/Button';
 import { Card } from '~/components/card';
+import { CheckIcon, CopyIcon, ExternalLinkIcon } from '~/components/icons';
 import { useServiceAccountEmail } from '~/features/host/hooks/useServiceAccountEmail';
 import { CALENDAR_ID_REGEX } from '~/features/host/utils/validation';
 import calendarSettingsGuide from '~/assets/images/host-register/calendar-settings-guide.png';
@@ -15,45 +16,6 @@ interface GoogleCalendarSetupProps {
     onChange: (data: GoogleCalendarSetupData) => void;
     errors: Record<string, string>;
     noShadow?: boolean;
-}
-
-export function CalendarIcon({ className = '' }: { className?: string }) {
-    return (
-        <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" strokeWidth="2" />
-            <path d="M3 10H21" stroke="currentColor" strokeWidth="2" />
-            <path d="M8 2V6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            <path d="M16 2V6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            <text x="12" y="18" textAnchor="middle" fill="currentColor" fontSize="7" fontWeight="bold">21</text>
-        </svg>
-    );
-}
-
-function ExternalLinkIcon({ className = '' }: { className?: string }) {
-    return (
-        <svg className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M6 3H3V13H13V10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M9 2H14V7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M14 2L7 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-    );
-}
-
-function CopyIcon({ className = '' }: { className?: string }) {
-    return (
-        <svg className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="5" y="5" width="9" height="9" rx="1" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M3 11V3C3 2.44772 3.44772 2 4 2H12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-    );
-}
-
-function CheckIcon({ className = '' }: { className?: string }) {
-    return (
-        <svg className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 8L6.5 11.5L13 4.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-    );
 }
 
 export default function GoogleCalendarSetup({ data, onChange, errors, noShadow }: GoogleCalendarSetupProps) {

--- a/frontend/src/features/host/components/register/RegisterStep2.tsx
+++ b/frontend/src/features/host/components/register/RegisterStep2.tsx
@@ -1,4 +1,5 @@
-import GoogleCalendarSetup, { CalendarIcon } from '../GoogleCalendarSetup';
+import { CalendarIcon } from '~/components/icons';
+import GoogleCalendarSetup from '../GoogleCalendarSetup';
 
 export interface Step2Data {
     googleCalendarId: string;


### PR DESCRIPTION
## 관련 이슈
- Closes #396

---

## 뭘 만들었나요? (What)

GoogleCalendarSetup.tsx 내 인라인 SVG 아이콘 4개를 ~/components/icons/ 디렉토리로 분리하여 재사용 가능한 컴포넌트로 변환

**분리된 아이콘:**
- CalendarIcon
- ExternalLinkIcon
- CopyIcon
- CheckIcon

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- 기존 CoffeeCupIcon.tsx의 패턴을 참고하여 일관된 아이콘 컴포넌트 구조 유지
- 배럴 파일(index.ts)을 통해 import 경로 단순화: `import { CalendarIcon } from '~/components/icons'`
- 아이콘을 컴포넌트 파일 외부로 분리하여 관심사 분리 및 재사용성 향상

---

## 어떻게 테스트했나요? (Test)

- pnpm build: 빌드 성공
- pnpm lint: 린트 통과 (기존 warning 1개만 존재)

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 프로덕션 빌드 성공 확인
2. TypeScript 타입 체크 통과 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- RegisterStep2.tsx의 import 경로가 `../GoogleCalendarSetup`에서 `~/components/icons`로 변경됨
- 모든 아이콘이 ~/components/icons/에서 중앙 관리되어 향후 다른 컴포넌트에서도 쉽게 재사용 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 아이콘 컴포넌트 추가: 캘린더, 체크, 복사, 외부 링크 아이콘 신규 추가

## 리팩토링
* 아이콘 라이브러리 통합: 산재된 아이콘을 중앙화하여 관리 및 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->