### PR TITLE
fix: #457 달력 월 이동 시 예약 데이터 즉시 갱신

### DIFF
--- a/frontend/src/features/booking/hooks/queryKeys.ts
+++ b/frontend/src/features/booking/hooks/queryKeys.ts
@@ -11,7 +11,9 @@ export const bookingKeys = {
 };
 
 export const calendarKeys = {
-    bookings: (year: number, month: number) => ['bookings', year, month] as const,
+    bookingsAll: () => ['bookings'] as const,
+    bookings: (hostname: string, year: number, month: number) =>
+        ['bookings', hostname, year, month] as const,
     timeslots: (hostname: string, hostId?: string) => ['timeslots', hostname, hostId] as const,
     calendarEvent: (slug: string) => ['calendar-event', slug] as const,
 };

--- a/frontend/src/features/booking/hooks/useBookings.ts
+++ b/frontend/src/features/booking/hooks/useBookings.ts
@@ -1,11 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { getBookingsByDate } from '../api/calendar';
-import type { IBooking } from '~/components/calendar';
 import { calendarKeys } from './queryKeys';
 
-export function useBookings(hostname: string, year: number, month: number) {
-    return useQuery<IBooking[]>({
-        queryKey: calendarKeys.bookings(year, month),
+interface UseBookingsParams {
+    hostname: string;
+    year: number;
+    month: number;
+}
+
+export function useBookings({ hostname, year, month }: UseBookingsParams) {
+    return useQuery({
+        queryKey: calendarKeys.bookings(hostname, year, month),
         queryFn: () => getBookingsByDate(hostname, { year, month }),
         enabled: !!hostname && year > 0 && month > 0,
     });

--- a/frontend/src/features/booking/index.ts
+++ b/frontend/src/features/booking/index.ts
@@ -25,6 +25,9 @@ export {
     useUpdateBooking,
 } from './hooks';
 
+// Query Keys
+export { bookingKeys, calendarKeys } from './hooks/queryKeys';
+
 // Types
 export type {
     IBookingDetail,

--- a/frontend/src/pages/host/Profile.tsx
+++ b/frontend/src/pages/host/Profile.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from '@tanstack/react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { PageLayout } from '~/components';
 import { Card } from '~/components/card';
 import { HostProfileCard } from '~/features/host/components/HostProfileCard';
@@ -7,87 +8,106 @@ import { HostTopicTags } from '~/features/host/components/HostTopicTags';
 import { Body, Navigator, Timeslots, getCalendarDays } from '~/components/calendar';
 import type { ITimeSlot } from '~/components/calendar';
 import { useHostProfile, useHostCalendar, useHostTimeslots } from '~/features/host/hooks/useHostProfile';
-import { useBookings, BookingForm } from '~/features/booking';
+import { useBookings, BookingForm, calendarKeys } from '~/features/booking';
 import { useAuth } from '~/features/member';
 
 const DEFAULT_TOPICS = ['개발 커리어', '이직 준비', '기술 면접', '스타트업 경험', '코드 리뷰'];
 
+const isMobile = () => window.innerWidth < 768;
+
 export function Profile() {
     const { hostId } = useParams({ from: '/host/$hostId' });
-    useEffect(() => { window.scrollTo(0, 0); }, [hostId]);
+    const queryClient = useQueryClient();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [hostId]);
 
     const { data: host, isLoading: isHostLoading, error: hostError } = useHostProfile(hostId);
     const { data: calendar } = useHostCalendar(hostId);
     const { data: timeslots = [] } = useHostTimeslots(host?.id);
-    const { data: authUser } = useAuth();
+    const { isAuthenticated, data: authUser } = useAuth();
 
-    const topics = calendar?.topics && calendar.topics.length > 0 ? calendar.topics : DEFAULT_TOPICS;
-    const description = calendar?.description;
+    const topics = useMemo(
+        () => (calendar?.topics?.length ? calendar.topics : DEFAULT_TOPICS),
+        [calendar?.topics]
+    );
 
-    const now = new Date();
+    const now = useMemo(() => new Date(), []);
     const [year, setYear] = useState(now.getFullYear());
     const [month, setMonth] = useState(now.getMonth() + 1);
     const [selectedDate, setSelectedDate] = useState<Date | null>(null);
     const [selectedTimeslot, setSelectedTimeslot] = useState<ITimeSlot | null>(null);
 
-    const { data: bookings = [], refetch: refetchBookings } = useBookings(
-        host?.username ?? '', year, month
-    );
+    const { data: bookings = [] } = useBookings({
+        hostname: host?.username ?? '',
+        year,
+        month,
+    });
 
     const timeslotsRef = useRef<HTMLDivElement>(null);
     const formRef = useRef<HTMLDivElement>(null);
 
-    const isSelf = authUser?.username === hostId;
+    const isSelf = isAuthenticated && authUser?.username === hostId;
 
-    const handlePrevMonth = (_slug: string, date: { year: number; month: number }) => {
-        setYear(date.year);
-        setMonth(date.month);
-    };
+    const handleMonthChange = useCallback(
+        (_slug: string, date: { year: number; month: number }) => {
+            setYear(date.year);
+            setMonth(date.month);
+        },
+        []
+    );
 
-    const handleNextMonth = (_slug: string, date: { year: number; month: number }) => {
-        setYear(date.year);
-        setMonth(date.month);
-    };
-
-    const isMobile = () => window.innerWidth < 768;
-
-    const handleSelectDay = (date: Date) => {
+    const handleSelectDay = useCallback((date: Date) => {
         setSelectedDate(date);
         setSelectedTimeslot(null);
         if (isMobile()) {
             setTimeout(() => timeslotsRef.current?.scrollIntoView({ behavior: 'smooth' }), 100);
         }
-    };
+    }, []);
 
-    const handleSelectTimeslot = (timeslot: ITimeSlot) => {
+    const handleSelectTimeslot = useCallback((timeslot: ITimeSlot) => {
         setSelectedTimeslot(timeslot);
         if (isMobile()) {
             setTimeout(() => formRef.current?.scrollIntoView({ behavior: 'smooth' }), 100);
         }
-    };
+    }, []);
 
-    const handleBookingCreated = () => {
+    const handleBookingCreated = useCallback(() => {
         setSelectedTimeslot(null);
         setSelectedDate(null);
-        refetchBookings();
-    };
+        if (host?.username) {
+            queryClient.invalidateQueries({
+                queryKey: calendarKeys.bookings(host.username, year, month),
+            });
+        }
+    }, [queryClient, host?.username, year, month]);
 
-    const title = isSelf
-        ? '내 프로필 미리보기'
-        : host ? `${host.displayName}님과 약속잡기` : '호스트 프로필';
+    const title = useMemo(() => {
+        if (isSelf) return '내 프로필 미리보기';
+        return host ? `${host.displayName}님과 약속잡기` : '호스트 프로필';
+    }, [isSelf, host]);
 
     return (
         <PageLayout title={title}>
             {isHostLoading && (
-                <div data-testid="host-profile-loading" className="flex items-center justify-center min-h-[60vh] text-gray-500">
+                <div
+                    data-testid="host-profile-loading"
+                    className="flex items-center justify-center min-h-[60vh] text-gray-500"
+                >
                     프로필을 불러오는 중...
                 </div>
             )}
 
             {hostError && (
-                <div data-testid="host-profile-error" className="flex flex-col items-center justify-center min-h-[60vh] text-gray-500 gap-4">
+                <div
+                    data-testid="host-profile-error"
+                    className="flex flex-col items-center justify-center min-h-[60vh] text-gray-500 gap-4"
+                >
                     <p>{(hostError as Error).message}</p>
-                    <Link to="/" className="text-[var(--cohi-primary)] hover:underline">홈으로 돌아가기</Link>
+                    <Link to="/" className="text-[var(--cohi-primary)] hover:underline">
+                        홈으로 돌아가기
+                    </Link>
                 </div>
             )}
 
@@ -96,15 +116,19 @@ export function Profile() {
                     <div className="md:w-1/3 md:min-w-[240px] space-y-6">
                         <HostProfileCard host={host} />
 
-                        {description && (
+                        {calendar?.description && (
                             <section data-testid="host-profile-description">
-                                <h2 className="text-lg font-semibold text-[var(--cohi-text-dark)] mb-3">소개</h2>
-                                <p className="text-gray-700 leading-relaxed">{description}</p>
+                                <h2 className="text-lg font-semibold text-[var(--cohi-text-dark)] mb-3">
+                                    소개
+                                </h2>
+                                <p className="text-gray-700 leading-relaxed">{calendar.description}</p>
                             </section>
                         )}
 
                         <section data-testid="host-profile-topics">
-                            <h2 className="text-lg font-semibold text-[var(--cohi-text-dark)] mb-3">토픽</h2>
+                            <h2 className="text-lg font-semibold text-[var(--cohi-text-dark)] mb-3">
+                                토픽
+                            </h2>
                             <HostTopicTags topics={topics} />
                         </section>
                     </div>
@@ -118,8 +142,8 @@ export function Profile() {
                                             slug={host.username}
                                             year={year}
                                             month={month}
-                                            onPrevious={handlePrevMonth}
-                                            onNext={handleNextMonth}
+                                            onPrevious={handleMonthChange}
+                                            onNext={handleMonthChange}
                                         />
                                         <div className="mt-4">
                                             <Body
@@ -134,7 +158,11 @@ export function Profile() {
                                         </div>
                                     </div>
 
-                                    <div ref={timeslotsRef} className="md:w-[200px] md:min-w-[200px]" data-testid="host-profile-timeslots">
+                                    <div
+                                        ref={timeslotsRef}
+                                        className="md:w-[200px] md:min-w-[200px]"
+                                        data-testid="host-profile-timeslots"
+                                    >
                                         {!isSelf && selectedDate ? (
                                             <Timeslots
                                                 timeslots={timeslots}
@@ -146,8 +174,10 @@ export function Profile() {
                                             <div className="hidden md:flex flex-col items-center justify-center h-full text-center text-gray-400 space-y-3 py-8">
                                                 <span className="text-4xl">&#x1F4C5;</span>
                                                 <p className="text-sm leading-relaxed">
-                                                    날짜를 선택하면<br />
-                                                    예약 가능한 시간대가<br />
+                                                    날짜를 선택하면
+                                                    <br />
+                                                    예약 가능한 시간대가
+                                                    <br />
                                                     표시됩니다
                                                 </p>
                                             </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #457

---

## 📦 뭘 만들었나요? (What)

호스트 프로필 페이지에서 달력 월 이동 시 예약 데이터가 갱신되지 않던 버그를 수정했습니다.

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- 기존: `useBookings(hostname, date)` - `date`가 `null`이면 쿼리 비활성화
- 문제: 월 이동 시 `year/month`만 변경되고 `selectedDate`는 `null` 유지 → bookings 갱신 안 됨
- 해결: `useBookings(hostname, year, month)` - year/month를 직접 queryKey에 사용
- React Query가 year/month 변경 시 자동으로 refetch

---

## 어떻게 테스트했나요? (Test)

- `pnpm test run` - 386개 테스트 전체 통과

---

## 참고사항 / 회고 메모 (Notes)

- 페이지 초기 진입 시에도 현재 월의 예약 데이터를 즉시 가져와 정확한 가용성 표시