### PR TITLE
fix: #459 페이지네이션 파라미터 유효성 검증 추가

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/booking/controller/BookingController.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/controller/BookingController.java
@@ -35,7 +35,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 
@@ -94,8 +94,8 @@ public class BookingController {
     @GetMapping("/guest/me")
     public ResponseEntity<ApiResponseDTO<PaginatedBookingResponseDTO>> getMyBookingsAsGuest(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.") int page,
-            @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") int size
+            @RequestParam(defaultValue = "1") @Positive int page,
+            @RequestParam(defaultValue = "10") @Positive int size
     ) {
         Member member = memberService.getMember(userDetails.getUsername());
         PaginatedBookingResponseDTO response = bookingService.getBookingsByGuestIdPaginated(member.getId(), page, size);
@@ -111,8 +111,8 @@ public class BookingController {
     @GetMapping("/host/me")
     public ResponseEntity<ApiResponseDTO<PaginatedBookingResponseDTO>> getMyBookingsAsHost(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.") int page,
-            @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") int size
+            @RequestParam(defaultValue = "1") @Positive int page,
+            @RequestParam(defaultValue = "10") @Positive int size
     ) {
         Member member = memberService.getMember(userDetails.getUsername());
         PaginatedBookingResponseDTO response = bookingService.getBookingsByHostIdPaginated(member.getId(), page, size);

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/BookingControllerTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/BookingControllerTest.java
@@ -17,7 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
@@ -26,6 +25,8 @@ import com.coDevs.cohiChat.booking.controller.BookingController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -791,72 +792,38 @@ class BookingControllerTest {
 
     // ===== 페이지네이션 파라미터 유효성 검증 테스트 (Issue #459) =====
 
-    @Test
-    @DisplayName("실패: page=0으로 게스트 예약 조회 - 400 Bad Request")
-    void getMyBookingsAsGuestFailInvalidPage() throws Exception {
-        // when & then
+    @ParameterizedTest(name = "page={0}, size={1}")
+    @CsvSource({
+        "0, 10",   // page=0
+        "1, 0",    // size=0
+        "-1, 10",  // 음수 page
+        "1, -5"    // 음수 size
+    })
+    @DisplayName("실패: 잘못된 페이지네이션으로 게스트 예약 조회 - 400 Bad Request")
+    void getMyBookingsAsGuestFailInvalidPagination(String page, String size) throws Exception {
         mockMvc.perform(get("/bookings/guest/me")
-                .param("page", "0")
-                .param("size", "10"))
+                .param("page", page)
+                .param("size", size))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
     }
 
-    @Test
-    @DisplayName("실패: size=0으로 게스트 예약 조회 - 400 Bad Request")
-    void getMyBookingsAsGuestFailInvalidSize() throws Exception {
-        // when & then
-        mockMvc.perform(get("/bookings/guest/me")
-                .param("page", "1")
-                .param("size", "0"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.success").value(false))
-            .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
-    }
-
-    @Test
-    @DisplayName("실패: 음수 page로 게스트 예약 조회 - 400 Bad Request")
-    void getMyBookingsAsGuestFailNegativePage() throws Exception {
-        // when & then
-        mockMvc.perform(get("/bookings/guest/me")
-                .param("page", "-1")
-                .param("size", "10"))
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("실패: page=0으로 호스트 예약 조회 - 400 Bad Request")
-    void getMyBookingsAsHostFailInvalidPage() throws Exception {
-        // when & then
+    @ParameterizedTest(name = "page={0}, size={1}")
+    @CsvSource({
+        "0, 10",   // page=0
+        "1, 0",    // size=0
+        "-1, 10",  // 음수 page
+        "1, -5"    // 음수 size
+    })
+    @DisplayName("실패: 잘못된 페이지네이션으로 호스트 예약 조회 - 400 Bad Request")
+    void getMyBookingsAsHostFailInvalidPagination(String page, String size) throws Exception {
         mockMvc.perform(get("/bookings/host/me")
-                .param("page", "0")
-                .param("size", "10"))
+                .param("page", page)
+                .param("size", size))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
-    }
-
-    @Test
-    @DisplayName("실패: size=0으로 호스트 예약 조회 - 400 Bad Request")
-    void getMyBookingsAsHostFailInvalidSize() throws Exception {
-        // when & then
-        mockMvc.perform(get("/bookings/host/me")
-                .param("page", "1")
-                .param("size", "0"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.success").value(false))
-            .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
-    }
-
-    @Test
-    @DisplayName("실패: 음수 size로 호스트 예약 조회 - 400 Bad Request")
-    void getMyBookingsAsHostFailNegativeSize() throws Exception {
-        // when & then
-        mockMvc.perform(get("/bookings/host/me")
-                .param("page", "1")
-                .param("size", "-5"))
-            .andExpect(status().isBadRequest());
     }
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #459

---

## 📦 뭘 만들었나요? (What)

페이지네이션 API에서 잘못된 page/size 값에 400 Bad Request를 반환하도록 수정했습니다.

### 변경 사항
- `BookingController`에 `@Validated` 어노테이션 추가
- `page`, `size` 파라미터에 `@Min(1)` 검증 추가
- OpenAPI 문서에 400 응답 추가

---

## 왜 이렇게 만들었나요? (Why)

- 기존: `page=0` 또는 `size=0` 시 `IllegalArgumentException` → 500 반환
- 수정: Spring `@Validated` + `@Min`으로 400 반환
- `GlobalExceptionHandler`가 이미 `ConstraintViolationException`을 400으로 처리

---

## 어떻게 테스트했나요? (Test)

- `./gradlew test` - 전체 테스트 통과
- page=0, size=0, 음수 값 테스트 케이스 추가

---

## 참고사항 / 회고 메모 (Notes)

- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 예약 조회 API의 페이지네이션 매개변수 검증이 강화되었습니다. 잘못된 페이지 또는 크기 값(1 미만)에 대해 400 Bad Request 응답을 반환합니다.
  * API 문서가 업데이트되어 유효하지 않은 페이지네이션 요청에 대한 오류 응답이 명시됩니다.

* **테스트**
  * 페이지네이션 검증 로직에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->