### PR TITLE
feat: #467 JVM 메트릭 로깅 서비스 추가

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/global/observability/MetricsLoggingService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/global/observability/MetricsLoggingService.java
@@ -1,0 +1,43 @@
+package com.coDevs.cohiChat.global.observability;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MetricsLoggingService {
+
+    private static final Logger log = LoggerFactory.getLogger(MetricsLoggingService.class);
+    private static final long BYTES_TO_MB = 1024 * 1024;
+
+    @Scheduled(fixedRate = 60000)
+    public void logJvmMetrics() {
+        MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+        MemoryUsage heapUsage = memoryBean.getHeapMemoryUsage();
+
+        long heapUsedMb = heapUsage.getUsed() / BYTES_TO_MB;
+        long heapMaxMb = heapUsage.getMax() / BYTES_TO_MB;
+        int heapPercent = heapMaxMb > 0 ? (int) (heapUsedMb * 100 / heapMaxMb) : 0;
+
+        long gcCount = 0;
+        long gcTimeMs = 0;
+        for (GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
+            gcCount += gc.getCollectionCount();
+            gcTimeMs += gc.getCollectionTime();
+        }
+
+        log.info(StructuredLogMessage.of("METRIC", "JVM")
+                .add("heap_used_mb", heapUsedMb)
+                .add("heap_max_mb", heapMaxMb)
+                .add("heap_percent", heapPercent)
+                .add("gc_count", gcCount)
+                .add("gc_time_ms", gcTimeMs)
+                .build());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #467

---

## 📦 뭘 만들었나요? (What)

기존 Vector 파이프라인을 활용하여 JVM 메트릭을 PostHog로 전송합니다.

### 추가된 파일
- `MetricsLoggingService.java` - 1분마다 JVM 메트릭 로깅

### 수집 메트릭
- heap_used_mb, heap_max_mb, heap_percent
- gc_count, gc_time_ms

---

## 왜 이렇게 만들었나요? (Why)

- 기존 Fluent Bit → Vector → PostHog 파이프라인 활용
- **추가 의존성 없음** (PostHog SDK 불필요)
- 구조화된 로그 출력 → Vector가 자동 파싱 → PostHog 전송

---

## 어떻게 테스트했나요? (Test)

- CI에서 빌드 검증

---

## 참고사항 / 회고 메모 (Notes)

로그 형식:
```
[METRIC] [JVM] heap_used_mb=256 heap_max_mb=512 heap_percent=50 gc_count=5 gc_time_ms=120
```