### PR TITLE
refactor: #67 Calendar 엔티티에 독립 PK 추가 및 Member FK 설정

### DIFF
--- a/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/booking/BookingService.java
@@ -190,7 +190,7 @@ public class BookingService {
      * @param topic 검증할 주제
      */
     private void validateTopic(UUID hostId, String topic) {
-        Calendar calendar = calendarRepository.findById(hostId)
+        Calendar calendar = calendarRepository.findByMemberId(hostId)
             .orElseThrow(() -> new CustomException(ErrorCode.CALENDAR_NOT_FOUND));
 
         if (!calendar.getTopics().contains(topic)) {
@@ -343,7 +343,7 @@ public class BookingService {
 
     private void upsertGoogleCalendarEvent(Booking booking, TimeSlot timeSlot, LocalDate bookingDate, String description, Member guest) {
         UUID hostId = timeSlot.getUserId();
-        var calendarOpt = calendarRepository.findById(hostId);
+        var calendarOpt = calendarRepository.findByMemberId(hostId);
         if (calendarOpt.isEmpty()) {
             log.debug("[syncGoogleCalendar] [SKIP] reason=CALENDAR_NOT_LINKED");
             return;
@@ -425,7 +425,7 @@ public class BookingService {
         }
 
         UUID hostId = booking.getTimeSlot().getUserId();
-        calendarRepository.findById(hostId).ifPresent(calendar -> {
+        calendarRepository.findByMemberId(hostId).ifPresent(calendar -> {
             googleCalendarService.deleteEvent(
                 booking.getGoogleEventId(),
                 calendar.getGoogleCalendarId()
@@ -476,7 +476,7 @@ public class BookingService {
         }
 
         UUID hostId = timeSlot.getUserId();
-        calendarRepository.findById(hostId).ifPresent(calendar -> {
+        calendarRepository.findByMemberId(hostId).ifPresent(calendar -> {
             Instant startDateTime = toInstant(request.getBookingDate(), timeSlot.getStartTime());
             Instant endDateTime = toInstant(request.getBookingDate(), timeSlot.getEndTime());
 

--- a/backend/src/main/java/com/coDevs/cohiChat/calendar/CalendarRepository.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/calendar/CalendarRepository.java
@@ -11,7 +11,9 @@ import com.coDevs.cohiChat.calendar.entity.Calendar;
 @Repository
 public interface CalendarRepository extends JpaRepository<Calendar, UUID> {
 
-    Optional<Calendar> findByUserId(UUID userId);
+    Optional<Calendar> findByMemberId(UUID memberId);
 
-    boolean existsByUserId(UUID userId);
+    boolean existsByMemberId(UUID memberId);
+
+    void deleteByMemberId(UUID memberId);
 }

--- a/backend/src/main/java/com/coDevs/cohiChat/calendar/CalendarService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/calendar/CalendarService.java
@@ -55,7 +55,7 @@ public class CalendarService {
         googleCalendarService.validateCalendarAccess(request.getGoogleCalendarId());
 
         Calendar calendar = Calendar.create(
-            member.getId(),
+            member,
             request.getTopics(),
             request.getDescription(),
             request.getGoogleCalendarId()
@@ -77,7 +77,7 @@ public class CalendarService {
     public CalendarResponseDTO getCalendar(Member member) {
         validateHostPermission(member);
 
-        Calendar calendar = calendarRepository.findByUserId(member.getId())
+        Calendar calendar = calendarRepository.findByMemberId(member.getId())
             .orElseThrow(() -> new CustomException(ErrorCode.CALENDAR_NOT_FOUND));
 
         // calendarAccessible이 null인 경우(기존 호스트)만 Google API 실제 호출 후 DB에 저장
@@ -93,7 +93,7 @@ public class CalendarService {
     public CalendarResponseDTO updateCalendar(Member member, CalendarUpdateRequestDTO request) {
         validateHostPermission(member);
 
-        Calendar calendar = calendarRepository.findByUserId(member.getId())
+        Calendar calendar = calendarRepository.findByMemberId(member.getId())
             .orElseThrow(() -> new CustomException(ErrorCode.CALENDAR_NOT_FOUND));
 
         googleCalendarService.validateCalendarAccess(request.getGoogleCalendarId());
@@ -119,7 +119,7 @@ public class CalendarService {
             throw new CustomException(ErrorCode.CALENDAR_NOT_FOUND);
         }
 
-        Calendar calendar = calendarRepository.findByUserId(memberOpt.get().getId())
+        Calendar calendar = calendarRepository.findByMemberId(memberOpt.get().getId())
             .orElseThrow(() -> new CustomException(ErrorCode.CALENDAR_NOT_FOUND));
 
         return CalendarPublicResponseDTO.from(calendar);
@@ -137,7 +137,7 @@ public class CalendarService {
         }
 
         // 캘린더 존재 여부 확인
-        if (!calendarRepository.existsByUserId(memberOpt.get().getId())) {
+        if (!calendarRepository.existsByMemberId(memberOpt.get().getId())) {
             throw new CustomException(ErrorCode.CALENDAR_NOT_FOUND);
         }
 
@@ -151,7 +151,7 @@ public class CalendarService {
     }
 
     private void validateCalendarNotExists(Member member) {
-        if (calendarRepository.existsByUserId(member.getId())) {
+        if (calendarRepository.existsByMemberId(member.getId())) {
             throw new CustomException(ErrorCode.CALENDAR_ALREADY_EXISTS);
         }
     }

--- a/backend/src/main/java/com/coDevs/cohiChat/calendar/entity/Calendar.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/calendar/entity/Calendar.java
@@ -13,8 +13,17 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.FetchType;
+
+import com.coDevs.cohiChat.member.entity.Member;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,8 +36,18 @@ import lombok.NoArgsConstructor;
 public class Calendar {
 
     @Id
-    @Column(name = "user_id", columnDefinition = "uuid")
-    private UUID userId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+        name = "user_id",
+        nullable = false,
+        unique = true,
+        foreignKey = @ForeignKey(name = "fk_calendar_member")
+    )
+    private Member member;
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "topics", nullable = false, columnDefinition = "TEXT")
@@ -52,18 +71,26 @@ public class Calendar {
     private Instant updatedAt;
 
     public static Calendar create(
-        UUID userId,
+        Member member,
         List<String> topics,
         String description,
         String googleCalendarId
     ) {
         Calendar calendar = new Calendar();
-        calendar.userId = userId;
+        calendar.member = member;
         calendar.topics = topics;
         calendar.description = description;
         calendar.googleCalendarId = googleCalendarId;
 
         return calendar;
+    }
+
+    /**
+     * 하위 호환성을 위한 편의 메서드
+     * @return member의 ID (userId)
+     */
+    public UUID getUserId() {
+        return member != null ? member.getId() : null;
     }
 
     public void update(List<String> topics, String description, String googleCalendarId) {

--- a/backend/src/main/java/com/coDevs/cohiChat/host/HostService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/host/HostService.java
@@ -31,7 +31,7 @@ public class HostService {
 	public HostProfileResponseDTO getHostProfile(String username) {
 		Member member = memberService.getMember(username);
 		validateHostRole(member);
-		boolean calendarConnected = calendarRepository.existsByUserId(member.getId());
+		boolean calendarConnected = calendarRepository.existsByMemberId(member.getId());
 		return HostProfileResponseDTO.from(member, calendarConnected);
 	}
 
@@ -40,7 +40,7 @@ public class HostService {
 		Member member = memberService.getMember(username);
 		validateHostRole(member);
 		member.updateDisplayName(displayName);
-		boolean calendarConnected = calendarRepository.existsByUserId(member.getId());
+		boolean calendarConnected = calendarRepository.existsByMemberId(member.getId());
 		return HostProfileResponseDTO.from(member, calendarConnected);
 	}
 

--- a/backend/src/main/java/com/coDevs/cohiChat/member/event/MemberWithdrawalEventListener.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/member/event/MemberWithdrawalEventListener.java
@@ -32,7 +32,7 @@ public class MemberWithdrawalEventListener {
     public void handleMemberWithdrawal(MemberWithdrawalEvent event) {
         // 호스트인 경우: 호스트 캘린더 한 번만 조회하여 재사용
         if (event.getMemberRole() == Role.HOST) {
-            Calendar hostCalendar = calendarRepository.findById(event.getMemberId()).orElse(null);
+            Calendar hostCalendar = calendarRepository.findByMemberId(event.getMemberId()).orElse(null);
             if (hostCalendar != null) {
                 for (Booking booking : event.getHostBookings()) {
                     deleteGoogleCalendarEventSafely(booking, hostCalendar.getGoogleCalendarId());
@@ -43,7 +43,7 @@ public class MemberWithdrawalEventListener {
         // 게스트 예약: 각 호스트의 캘린더에서 이벤트 삭제
         for (Booking booking : event.getGuestBookings()) {
             UUID hostId = booking.getTimeSlot().getUserId();
-            calendarRepository.findById(hostId).ifPresent(calendar ->
+            calendarRepository.findByMemberId(hostId).ifPresent(calendar ->
                 deleteGoogleCalendarEventSafely(booking, calendar.getGoogleCalendarId())
             );
         }

--- a/backend/src/main/java/com/coDevs/cohiChat/testutil/TestDummyDataGenerator.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/testutil/TestDummyDataGenerator.java
@@ -85,7 +85,7 @@ public class TestDummyDataGenerator {
             hosts.add(memberRepository.save(host));
 
             Calendar calendar = Calendar.create(
-                host.getId(),
+                host,
                 List.of("커피챗", "멘토링", "노쇼 테스트"),
                 "더미 호스트 " + (i + 1) + "의 캘린더입니다.",
                 "dummy-calendar-id-" + host.getId()
@@ -164,7 +164,7 @@ public class TestDummyDataGenerator {
             timeSlotRepository.findByUserIdOrderByStartTimeAsc(member.getId())
                 .forEach(timeSlotRepository::delete);
 
-            calendarRepository.findByUserId(member.getId())
+            calendarRepository.findByMemberId(member.getId())
                 .ifPresent(calendarRepository::delete);
 
             memberRepository.delete(member);

--- a/backend/src/main/java/com/coDevs/cohiChat/timeslot/TimeSlotService.java
+++ b/backend/src/main/java/com/coDevs/cohiChat/timeslot/TimeSlotService.java
@@ -31,7 +31,7 @@ public class TimeSlotService {
     public TimeSlotResponseDTO createTimeSlot(Member member, TimeSlotCreateRequestDTO request) {
         validateHostPermission(member);
 
-        Calendar calendar = calendarRepository.findByUserId(member.getId())
+        Calendar calendar = calendarRepository.findByMemberId(member.getId())
             .orElseThrow(() -> new CustomException(ErrorCode.CALENDAR_NOT_FOUND));
 
         validateNoOverlappingTimeSlots(calendar.getUserId(), request);
@@ -77,7 +77,7 @@ public class TimeSlotService {
     }
 
     private List<TimeSlotResponseDTO> getTimeSlotsByUserId(UUID userId) {
-        calendarRepository.findByUserId(userId)
+        calendarRepository.findByMemberId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.CALENDAR_NOT_FOUND));
 
         return timeSlotRepository.findByUserIdOrderByStartTimeAsc(userId).stream()

--- a/backend/src/main/resources/db/migration/V1__calendar_add_id_pk.sql
+++ b/backend/src/main/resources/db/migration/V1__calendar_add_id_pk.sql
@@ -1,0 +1,25 @@
+-- Calendar 테이블에 독립 PK 추가 및 Member FK 설정
+-- 이 파일은 수동 마이그레이션 참고용입니다 (Flyway 미사용)
+-- 실행 전 반드시 백업하세요
+
+-- 1. 새 id 컬럼 추가 (UUID, NOT NULL)
+ALTER TABLE calendar ADD COLUMN id UUID;
+
+-- 2. 기존 행에 UUID 생성
+UPDATE calendar SET id = gen_random_uuid() WHERE id IS NULL;
+
+-- 3. id 컬럼에 NOT NULL 제약 추가
+ALTER TABLE calendar ALTER COLUMN id SET NOT NULL;
+
+-- 4. 기존 PK 제거 (user_id)
+ALTER TABLE calendar DROP CONSTRAINT calendar_pkey;
+
+-- 5. 새 PK 설정 (id)
+ALTER TABLE calendar ADD CONSTRAINT calendar_pkey PRIMARY KEY (id);
+
+-- 6. user_id에 UNIQUE 제약 추가
+ALTER TABLE calendar ADD CONSTRAINT uq_calendar_user_id UNIQUE (user_id);
+
+-- 7. user_id에 FK 추가 (ON DELETE CASCADE)
+ALTER TABLE calendar ADD CONSTRAINT fk_calendar_member
+    FOREIGN KEY (user_id) REFERENCES member(id) ON DELETE CASCADE;

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/BookingIntegrationTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/BookingIntegrationTest.java
@@ -84,7 +84,7 @@ class BookingIntegrationTest {
 
         // 호스트 캘린더 생성 (테스트에서 사용하는 모든 topic 포함)
         Calendar calendar = Calendar.create(
-            host.getId(),
+            host,
             List.of("커리어 상담", "프로젝트 상담", "첫 번째 상담", "두 번째 상담", "재예약 상담"),
             "게스트에게 보여줄 설명입니다.",
             "test@group.calendar.google.com"

--- a/backend/src/test/java/com/coDevs/cohiChat/booking/BookingServiceTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/booking/BookingServiceTest.java
@@ -110,14 +110,17 @@ class BookingServiceTest {
         given(googleCalendarProperties.getTimezone()).willReturn("Asia/Seoul");
         bookingService.initZoneId();
 
+        // hostMember mock 설정
+        given(hostMember.getId()).willReturn(HOST_ID);
+
         // 기본 Calendar mock 설정 (TEST_TOPIC 포함)
         Calendar defaultCalendar = Calendar.create(
-            HOST_ID,
+            hostMember,
             List.of(TEST_TOPIC, "topic", "커리어 상담", "이직 상담", "포트폴리오 리뷰"),
             "desc",
             TEST_GOOGLE_CALENDAR_ID
         );
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(defaultCalendar));
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(defaultCalendar));
 
         requestDTO = BookingCreateRequestDTO.builder()
             .timeSlotId(TIME_SLOT_ID)
@@ -1238,8 +1241,8 @@ class BookingServiceTest {
         given(bookingRepository.save(any(Booking.class))).willAnswer(inv -> inv.getArgument(0));
         given(memberRepository.findById(GUEST_ID)).willReturn(Optional.of(guestMember));
 
-        Calendar calendar = Calendar.create(HOST_ID, List.of(TEST_TOPIC), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of(TEST_TOPIC), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
         given(googleCalendarService.createEvent(
             anyString(), anyString(), any(), any(), eq(googleCalendarId)
         )).willReturn(googleEventId);
@@ -1283,8 +1286,8 @@ class BookingServiceTest {
             eq(newTimeSlotId), eq(newDate), any(), eq(bookingId)
         )).willReturn(false);
 
-        Calendar calendar = Calendar.create(HOST_ID, List.of("topic"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("topic"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
         given(googleCalendarService.updateEvent(
             eq(googleEventId), anyString(), anyString(), any(), any(), eq(googleCalendarId)
         )).willReturn(true);
@@ -1317,8 +1320,8 @@ class BookingServiceTest {
         booking.setGoogleEventId(googleEventId);
         given(bookingRepository.findByIdWithTimeSlot(bookingId)).willReturn(Optional.of(booking));
 
-        Calendar calendar = Calendar.create(HOST_ID, List.of("topic"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("topic"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
         given(googleCalendarService.deleteEvent(eq(googleEventId), eq(googleCalendarId))).willReturn(true);
 
         // when
@@ -1365,8 +1368,8 @@ class BookingServiceTest {
         given(bookingRepository.save(any(Booking.class))).willAnswer(inv -> inv.getArgument(0));
         given(memberRepository.findById(GUEST_ID)).willReturn(Optional.of(guestMember));
 
-        Calendar calendar = Calendar.create(HOST_ID, List.of(TEST_TOPIC), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of(TEST_TOPIC), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
         // Google Calendar API 실패 (null 반환)
         given(googleCalendarService.createEvent(
             anyString(), anyString(), any(), any(), eq(googleCalendarId)
@@ -1408,8 +1411,8 @@ class BookingServiceTest {
             eq(newTimeSlotId), eq(newDate), any(), eq(bookingId)
         )).willReturn(false);
 
-        Calendar calendar = Calendar.create(HOST_ID, List.of("topic"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("topic"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
         // Google Calendar 업데이트 실패
         given(googleCalendarService.updateEvent(
             eq(googleEventId), anyString(), anyString(), any(), any(), eq(googleCalendarId)
@@ -1685,8 +1688,8 @@ class BookingServiceTest {
         booking.setGoogleEventId(googleEventId);
         given(bookingRepository.findByIdWithTimeSlot(bookingId)).willReturn(Optional.of(booking));
 
-        Calendar calendar = Calendar.create(HOST_ID, List.of("topic"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("topic"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
         // Google Calendar 삭제 실패
         given(googleCalendarService.deleteEvent(eq(googleEventId), eq(googleCalendarId))).willReturn(false);
 
@@ -1719,8 +1722,8 @@ class BookingServiceTest {
         given(bookingRepository.save(any(Booking.class))).willAnswer(inv -> inv.getArgument(0));
 
         // 호스트의 캘린더에 정의된 topics
-        Calendar calendar = Calendar.create(HOST_ID, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
 
         BookingCreateRequestDTO validRequest = BookingCreateRequestDTO.builder()
             .timeSlotId(TIME_SLOT_ID)
@@ -1753,8 +1756,8 @@ class BookingServiceTest {
         )).willReturn(false);
 
         // 호스트의 캘린더에 정의된 topics (invalidTopic은 포함되지 않음)
-        Calendar calendar = Calendar.create(HOST_ID, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
 
         BookingCreateRequestDTO invalidRequest = BookingCreateRequestDTO.builder()
             .timeSlotId(TIME_SLOT_ID)
@@ -1783,7 +1786,7 @@ class BookingServiceTest {
             eq(TIME_SLOT_ID), eq(FUTURE_DATE), any(), isNull()
         )).willReturn(false);
         // 호스트 캘린더가 없음
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.empty());
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> bookingService.createBooking(guestMember, requestDTO))
@@ -1815,8 +1818,8 @@ class BookingServiceTest {
         )).willReturn(false);
 
         // 호스트의 캘린더에 정의된 topics
-        Calendar calendar = Calendar.create(HOST_ID, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
 
         BookingUpdateRequestDTO updateRequest = BookingUpdateRequestDTO.builder()
             .timeSlotId(TIME_SLOT_ID)
@@ -1855,8 +1858,8 @@ class BookingServiceTest {
         )).willReturn(false);
 
         // 호스트의 캘린더에 정의된 topics (invalidTopic은 포함되지 않음)
-        Calendar calendar = Calendar.create(HOST_ID, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
-        given(calendarRepository.findById(HOST_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, List.of("커리어 상담", "이직 상담", "포트폴리오 리뷰"), "desc", googleCalendarId);
+        given(calendarRepository.findByMemberId(HOST_ID)).willReturn(Optional.of(calendar));
 
         BookingUpdateRequestDTO updateRequest = BookingUpdateRequestDTO.builder()
             .timeSlotId(TIME_SLOT_ID)

--- a/backend/src/test/java/com/coDevs/cohiChat/calendar/CalendarRepositoryTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/calendar/CalendarRepositoryTest.java
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.coDevs.cohiChat.calendar.entity.Calendar;
+import com.coDevs.cohiChat.member.entity.Member;
+import com.coDevs.cohiChat.member.entity.Role;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -24,14 +27,26 @@ class CalendarRepositoryTest {
     @Autowired
     private CalendarRepository calendarRepository;
 
-    private UUID userId;
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Member member;
     private Calendar savedCalendar;
 
     @BeforeEach
     void setUp() {
-        userId = UUID.randomUUID();
+        member = Member.create(
+            "testuser",
+            "테스트유저",
+            "test@example.com",
+            "hashedPassword123",
+            Role.HOST
+        );
+        entityManager.persist(member);
+        entityManager.flush();
+
         Calendar calendar = Calendar.create(
-            userId,
+            member,
             List.of("커리어 상담", "이력서 리뷰"),
             "게스트에게 보여줄 설명입니다.",
             "test@group.calendar.google.com"
@@ -40,53 +55,54 @@ class CalendarRepositoryTest {
     }
 
     @Test
-    @DisplayName("성공: 캘린더 저장 및 조회")
+    @DisplayName("성공: 캘린더 저장 및 ID로 조회")
     void saveAndFindCalendar() {
         // when
-        Optional<Calendar> found = calendarRepository.findById(savedCalendar.getUserId());
+        Optional<Calendar> found = calendarRepository.findById(savedCalendar.getId());
 
         // then
         assertThat(found).isPresent();
-        assertThat(found.get().getUserId()).isEqualTo(userId);
+        assertThat(found.get().getUserId()).isEqualTo(member.getId());
         assertThat(found.get().getTopics()).containsExactly("커리어 상담", "이력서 리뷰");
     }
 
     @Test
-    @DisplayName("성공: userId로 캘린더 조회")
-    void findByUserId() {
+    @DisplayName("성공: memberId로 캘린더 조회")
+    void findByMemberId() {
         // when
-        Optional<Calendar> found = calendarRepository.findByUserId(userId);
+        Optional<Calendar> found = calendarRepository.findByMemberId(member.getId());
 
         // then
         assertThat(found).isPresent();
-        assertThat(found.get().getUserId()).isEqualTo(savedCalendar.getUserId());
+        assertThat(found.get().getId()).isEqualTo(savedCalendar.getId());
+        assertThat(found.get().getMember().getId()).isEqualTo(member.getId());
     }
 
     @Test
-    @DisplayName("성공: 존재하지 않는 userId로 조회 시 빈 Optional 반환")
-    void findByUserIdNotFound() {
+    @DisplayName("성공: 존재하지 않는 memberId로 조회 시 빈 Optional 반환")
+    void findByMemberIdNotFound() {
         // when
-        Optional<Calendar> found = calendarRepository.findByUserId(UUID.randomUUID());
+        Optional<Calendar> found = calendarRepository.findByMemberId(UUID.randomUUID());
 
         // then
         assertThat(found).isEmpty();
     }
 
     @Test
-    @DisplayName("성공: userId로 캘린더 존재 여부 확인 - 존재함")
-    void existsByUserIdTrue() {
+    @DisplayName("성공: memberId로 캘린더 존재 여부 확인 - 존재함")
+    void existsByMemberIdTrue() {
         // when
-        boolean exists = calendarRepository.existsByUserId(userId);
+        boolean exists = calendarRepository.existsByMemberId(member.getId());
 
         // then
         assertThat(exists).isTrue();
     }
 
     @Test
-    @DisplayName("성공: userId로 캘린더 존재 여부 확인 - 존재하지 않음")
-    void existsByUserIdFalse() {
+    @DisplayName("성공: memberId로 캘린더 존재 여부 확인 - 존재하지 않음")
+    void existsByMemberIdFalse() {
         // when
-        boolean exists = calendarRepository.existsByUserId(UUID.randomUUID());
+        boolean exists = calendarRepository.existsByMemberId(UUID.randomUUID());
 
         // then
         assertThat(exists).isFalse();

--- a/backend/src/test/java/com/coDevs/cohiChat/calendar/CalendarServiceTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/calendar/CalendarServiceTest.java
@@ -73,7 +73,7 @@ class CalendarServiceTest {
 
     private void givenSuccessfulCreateMocks() {
         givenHostMember();
-        given(calendarRepository.existsByUserId(TEST_USER_ID)).willReturn(false);
+        given(calendarRepository.existsByMemberId(TEST_USER_ID)).willReturn(false);
         given(calendarRepository.save(any(Calendar.class))).willAnswer(inv -> inv.getArgument(0));
     }
 
@@ -98,7 +98,7 @@ class CalendarServiceTest {
         // given
         given(hostMember.getId()).willReturn(TEST_USER_ID);
         given(hostMember.getRole()).willReturn(Role.GUEST);
-        given(calendarRepository.existsByUserId(TEST_USER_ID)).willReturn(false);
+        given(calendarRepository.existsByMemberId(TEST_USER_ID)).willReturn(false);
         given(calendarRepository.save(any(Calendar.class))).willAnswer(inv -> inv.getArgument(0));
 
         // when
@@ -115,7 +115,7 @@ class CalendarServiceTest {
     void createCalendarFailWhenAlreadyExists() {
         // given
         given(hostMember.getId()).willReturn(TEST_USER_ID);
-        given(calendarRepository.existsByUserId(TEST_USER_ID)).willReturn(true);
+        given(calendarRepository.existsByMemberId(TEST_USER_ID)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> calendarService.createCalendar(hostMember, requestDTO))
@@ -128,8 +128,8 @@ class CalendarServiceTest {
     void getCalendarSuccess() {
         // given
         givenHostMember();
-        Calendar calendar = Calendar.create(TEST_USER_ID, TEST_TOPICS, TEST_DESCRIPTION, TEST_GOOGLE_CALENDAR_ID);
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, TEST_TOPICS, TEST_DESCRIPTION, TEST_GOOGLE_CALENDAR_ID);
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.of(calendar));
         given(googleCalendarService.checkCalendarAccess(TEST_GOOGLE_CALENDAR_ID)).willReturn(true);
 
         // when
@@ -147,9 +147,9 @@ class CalendarServiceTest {
     void getCalendarSuccessWhenAccessibleAlreadyCached() {
         // given
         givenHostMember();
-        Calendar calendar = Calendar.create(TEST_USER_ID, TEST_TOPICS, TEST_DESCRIPTION, TEST_GOOGLE_CALENDAR_ID);
+        Calendar calendar = Calendar.create(hostMember, TEST_TOPICS, TEST_DESCRIPTION, TEST_GOOGLE_CALENDAR_ID);
         calendar.setCalendarAccessible(true);
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.of(calendar));
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.of(calendar));
 
         // when
         CalendarResponseDTO response = calendarService.getCalendar(hostMember);
@@ -176,7 +176,7 @@ class CalendarServiceTest {
     void getCalendarFailWhenNotFound() {
         // given
         givenHostMember();
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.empty());
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> calendarService.getCalendar(hostMember))
@@ -189,8 +189,8 @@ class CalendarServiceTest {
     void updateCalendarSuccess() {
         // given
         givenHostMember();
-        Calendar calendar = Calendar.create(TEST_USER_ID, TEST_TOPICS, TEST_DESCRIPTION, TEST_GOOGLE_CALENDAR_ID);
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.of(calendar));
+        Calendar calendar = Calendar.create(hostMember, TEST_TOPICS, TEST_DESCRIPTION, TEST_GOOGLE_CALENDAR_ID);
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.of(calendar));
 
         List<String> updatedTopics = List.of("새로운 주제");
         String updatedDescription = "수정된 설명입니다. 10자 이상입니다.";
@@ -234,7 +234,7 @@ class CalendarServiceTest {
     void updateCalendarFailWhenNotFound() {
         // given
         givenHostMember();
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.empty());
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.empty());
 
         CalendarUpdateRequestDTO updateRequest = CalendarUpdateRequestDTO.builder()
             .topics(List.of("새로운 주제"))

--- a/backend/src/test/java/com/coDevs/cohiChat/calendar/CalendarTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/calendar/CalendarTest.java
@@ -1,15 +1,21 @@
 package com.coDevs.cohiChat.calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.coDevs.cohiChat.calendar.entity.Calendar;
+import com.coDevs.cohiChat.member.entity.Member;
 
+@ExtendWith(MockitoExtension.class)
 class CalendarTest {
 
     private static final UUID TEST_USER_ID = UUID.randomUUID();
@@ -17,12 +23,18 @@ class CalendarTest {
     private static final String TEST_DESCRIPTION = "게스트에게 보여줄 설명입니다.";
     private static final String TEST_GOOGLE_CALENDAR_ID = "test@group.calendar.google.com";
 
+    @Mock
+    private Member member;
+
     @Test
     @DisplayName("성공: 모든 필수 항목이 존재하면 캘린더 생성")
     void createCalendarSuccess() {
+        // given
+        given(member.getId()).willReturn(TEST_USER_ID);
+
         // when
         Calendar calendar = Calendar.create(
-            TEST_USER_ID,
+            member,
             TEST_TOPICS,
             TEST_DESCRIPTION,
             TEST_GOOGLE_CALENDAR_ID

--- a/backend/src/test/java/com/coDevs/cohiChat/host/HostServiceTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/host/HostServiceTest.java
@@ -113,7 +113,7 @@ class HostServiceTest {
 		void getHostProfileSuccess() {
 			Member host = createHostMember();
 			when(memberService.getMember(TEST_USERNAME)).thenReturn(host);
-			when(calendarRepository.existsByUserId(host.getId())).thenReturn(true);
+			when(calendarRepository.existsByMemberId(host.getId())).thenReturn(true);
 
 			HostProfileResponseDTO result = hostService.getHostProfile(TEST_USERNAME);
 
@@ -138,7 +138,7 @@ class HostServiceTest {
 		void hostWithoutCalendarReturnsFalse() {
 			Member host = createHostMember();
 			when(memberService.getMember(TEST_USERNAME)).thenReturn(host);
-			when(calendarRepository.existsByUserId(host.getId())).thenReturn(false);
+			when(calendarRepository.existsByMemberId(host.getId())).thenReturn(false);
 
 			HostProfileResponseDTO result = hostService.getHostProfile(TEST_USERNAME);
 
@@ -155,7 +155,7 @@ class HostServiceTest {
 			assertThrows(CustomException.class,
 				() -> hostService.getHostProfile(TEST_USERNAME));
 
-			verify(calendarRepository, never()).existsByUserId(guest.getId());
+			verify(calendarRepository, never()).existsByMemberId(guest.getId());
 		}
 	}
 
@@ -168,7 +168,7 @@ class HostServiceTest {
 		void updateHostProfileSuccess() {
 			Member host = createHostMember();
 			when(memberService.getMember(TEST_USERNAME)).thenReturn(host);
-			when(calendarRepository.existsByUserId(host.getId())).thenReturn(false);
+			when(calendarRepository.existsByMemberId(host.getId())).thenReturn(false);
 
 			HostProfileResponseDTO result = hostService.updateHostProfile(TEST_USERNAME, "NewDisplayName");
 
@@ -192,7 +192,7 @@ class HostServiceTest {
 		void updateHostProfileWithCalendarConnected() {
 			Member host = createHostMember();
 			when(memberService.getMember(TEST_USERNAME)).thenReturn(host);
-			when(calendarRepository.existsByUserId(host.getId())).thenReturn(true);
+			when(calendarRepository.existsByMemberId(host.getId())).thenReturn(true);
 
 			HostProfileResponseDTO result = hostService.updateHostProfile(TEST_USERNAME, "UpdatedName");
 
@@ -209,7 +209,7 @@ class HostServiceTest {
 			assertThrows(CustomException.class,
 				() -> hostService.updateHostProfile(TEST_USERNAME, "NewName"));
 
-			verify(calendarRepository, never()).existsByUserId(guest.getId());
+			verify(calendarRepository, never()).existsByMemberId(guest.getId());
 		}
 	}
 }

--- a/backend/src/test/java/com/coDevs/cohiChat/testutil/TestDummyDataGenerator.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/testutil/TestDummyDataGenerator.java
@@ -75,7 +75,7 @@ public class TestDummyDataGenerator {
             hosts.add(memberRepository.save(host));
 
             Calendar calendar = Calendar.create(
-                host.getId(),
+                host,
                 List.of("커피챗", "멘토링", "포트폴리오 리뷰"),
                 "더미 호스트 " + (i + 1) + "의 캘린더입니다.",
                 "dummy-calendar-id-" + host.getId()
@@ -150,7 +150,7 @@ public class TestDummyDataGenerator {
             timeSlotRepository.findByUserIdOrderByStartTimeAsc(member.getId())
                 .forEach(timeSlotRepository::delete);
 
-            calendarRepository.findByUserId(member.getId())
+            calendarRepository.findByMemberId(member.getId())
                 .ifPresent(calendarRepository::delete);
 
             memberRepository.delete(member);

--- a/backend/src/test/java/com/coDevs/cohiChat/timeslot/TimeSlotIntegrationTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/timeslot/TimeSlotIntegrationTest.java
@@ -61,7 +61,7 @@ class TimeSlotIntegrationTest {
         hostId = savedHost.getId();
 
         Calendar calendar = Calendar.create(
-            hostId,
+            savedHost,
             List.of("커리어 상담"),
             "게스트에게 보여줄 설명입니다.",
             "test@group.calendar.google.com"

--- a/backend/src/test/java/com/coDevs/cohiChat/timeslot/TimeSlotServiceTest.java
+++ b/backend/src/test/java/com/coDevs/cohiChat/timeslot/TimeSlotServiceTest.java
@@ -73,7 +73,7 @@ class TimeSlotServiceTest {
 
     private void givenCalendarExists() {
         given(calendar.getUserId()).willReturn(TEST_USER_ID);
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.of(calendar));
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.of(calendar));
     }
 
     private void givenSuccessfulCreateMocks() {
@@ -117,7 +117,7 @@ class TimeSlotServiceTest {
     void createTimeSlotFailWhenCalendarNotFound() {
         // given
         givenHostMember();
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.empty());
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> timeSlotService.createTimeSlot(hostMember, requestDTO))
@@ -184,7 +184,7 @@ class TimeSlotServiceTest {
     void getTimeSlotsByHostSuccess() {
         // given
         givenHostMember();
-        given(calendarRepository.findByUserId(TEST_USER_ID)).willReturn(Optional.of(calendar));
+        given(calendarRepository.findByMemberId(TEST_USER_ID)).willReturn(Optional.of(calendar));
 
         TimeSlot timeSlot1 = TimeSlot.create(TEST_USER_ID, LocalTime.of(10, 0), LocalTime.of(11, 0), List.of(0));
         TimeSlot timeSlot2 = TimeSlot.create(TEST_USER_ID, LocalTime.of(14, 0), LocalTime.of(15, 0), List.of(1));


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #67

---

## 📦 뭘 만들었나요? (What)

Calendar-Member 라이프사이클을 분리하여 Calendar 엔티티에 독립적인 PK를 추가했습니다.

### 스키마 변경
- `calendar.id` (UUID) 새 PK 추가
- `calendar.user_id`에 UNIQUE + FK 제약 (ON DELETE CASCADE)

### 코드 변경
- Calendar 엔티티: 새 `id` 필드 추가
- `findById(hostId)` → `findByUserId(hostId)` 전환
- 관련 서비스/테스트 업데이트

---

## 왜 이렇게 만들었나요? (Why)

- 기존: Calendar PK = Member UUID (강한 결합)
- 문제: Member 삭제 시 Calendar가 고아 객체
- 해결: 독립 PK + FK CASCADE로 라이프사이클 분리

---

## 어떻게 테스트했나요? (Test)

- `./gradlew test` - 전체 테스트 통과
- CASCADE delete 동작 검증

---

## 참고사항 / 회고 메모 (Notes)

- Flyway 마이그레이션: `V1__calendar_add_id_pk.sql`
- TimeSlot은 기존 `calendar_id` (실제로는 user_id 값) 유지