### PR TITLE
test: #466 프론트 테스트 mock 안정화

### DIFF
--- a/frontend/src/components/header/ProfileDropdown.test.tsx
+++ b/frontend/src/components/header/ProfileDropdown.test.tsx
@@ -4,10 +4,27 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-vi.mock('@tanstack/react-router', () => ({
-    Link: ({ children, to, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
-        React.createElement('a', { href: to, ...props }, children),
-}));
+vi.mock('@tanstack/react-router', () => {
+    type MockLinkProps = React.PropsWithChildren<
+        React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
+    >;
+
+    const MockLink = React.forwardRef<
+        HTMLAnchorElement,
+        MockLinkProps
+    >(({ children, to, ...props }, ref) =>
+        React.createElement(
+            'a',
+            { ref, href: typeof to === 'string' ? to : undefined, ...props },
+            children,
+        ),
+    );
+    MockLink.displayName = 'MockLink';
+
+    return {
+        Link: MockLink,
+    };
+});
 
 const mockLogout = vi.fn();
 const mockUseAuth = vi.fn();

--- a/frontend/src/features/member/hooks/useLogout.test.ts
+++ b/frontend/src/features/member/hooks/useLogout.test.ts
@@ -83,12 +83,14 @@ describe('useLogout', () => {
 
     it('API 실패 시 토스트를 표시하고 로컬 상태와 네비게이션을 실행하지 않는다', async () => {
         vi.mocked(logoutApi).mockRejectedValue(new Error('Network error'));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
         const { result } = renderHook(() => useLogout(), {
             wrapper: createWrapper(),
         });
 
         await result.current.logout();
+        expect(warnSpy).toHaveBeenCalledWith('Logout API error:', expect.any(Error));
         expect(mockShowToast).toHaveBeenCalledWith(
             '로그아웃에 실패했습니다. 잠시 후 다시 시도해 주세요.',
             'logout-error',

--- a/frontend/src/pages/host/Register.test.tsx
+++ b/frontend/src/pages/host/Register.test.tsx
@@ -28,6 +28,13 @@ vi.mock('~/features/member/utils/authEvent', () => ({
     dispatchAuthChange: vi.fn(),
 }));
 
+vi.mock('~/features/host/hooks/useServiceAccountEmail', () => ({
+    useServiceAccountEmail: () => ({
+        serviceAccountEmail: 'service-account@test.iam.gserviceaccount.com',
+        isError: false,
+    }),
+}));
+
 vi.mock('~/features/member', () => ({
     useAuth: () => ({ isAuthenticated: false, isLoading: false, data: null }),
     useLogout: () => ({ logout: vi.fn() }),

--- a/frontend/src/pages/host/Settings.test.tsx
+++ b/frontend/src/pages/host/Settings.test.tsx
@@ -27,6 +27,13 @@ vi.mock('~/features/member', () => ({
     useLogout: () => ({ logout: vi.fn() }),
 }));
 
+vi.mock('~/features/host/hooks/useServiceAccountEmail', () => ({
+    useServiceAccountEmail: () => ({
+        serviceAccountEmail: 'service-account@test.iam.gserviceaccount.com',
+        isError: false,
+    }),
+}));
+
 const createWrapper = () => {
     const queryClient = new QueryClient({
         defaultOptions: {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #466

---

## 📦 뭘 만들었나요? (What)

호스트 등록/설정 페이지 테스트가 실제 서비스 계정 이메일 API를 호출하지 않도록 mock을 추가했습니다.
ProfileDropdown 테스트의 Link mock을 forwardRef로 바꿔 Radix ref 경고를 제거했습니다.
로그아웃 실패 테스트에서 console.warn을 spy 처리해 테스트 출력 노이즈를 줄였습니다.

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

GoogleCalendarSetup가 테스트 중 실제 `localhost:8080` 요청을 보내면서 `ECONNREFUSED` stderr를 남기고 있었습니다.
또한 Radix Dropdown은 `asChild` 대상이 ref 전달 가능해야 해서 기존 Link mock이 경고를 만들고 있었습니다.
테스트를 네트워크와 DOM 계약에 맞게 고정해서 로컬/CI 실행 결과를 더 안정적으로 만들었습니다.

---

## 어떻게 테스트했나요? (Test)

- `pnpm build`
- `pnpm test -- --run`

<details>
<summary>테스트 시나리오 (선택)</summary>

1. Register/Settings 테스트 실행 시 service-account fetch가 외부로 새지 않는지 확인
2. ProfileDropdown 테스트 실행 시 ref warning 없이 드롭다운 상호작용이 통과하는지 확인
3. logout 실패 테스트가 warning assertion과 함께 통과하는지 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 프론트엔드 테스트 안정화만 포함한 PR입니다.
- 백엔드 로컬 실행 확인 중 보인 `member.is_banned` 스키마 이슈는 이번 PR 범위에 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 프로필 드롭다운 컴포넌트 테스트 개선
  * 로그아웃 기능 테스트 강화
  * 호스트 등록 및 설정 페이지 테스트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->