### PR TITLE
feat: #479 호스트 등록하기 메뉴 임시 제거

### DIFF
--- a/frontend/src/components/header/ProfileDropdown.test.tsx
+++ b/frontend/src/components/header/ProfileDropdown.test.tsx
@@ -71,7 +71,7 @@ describe('ProfileDropdown', () => {
         expect(screen.getByTestId('profile-dropdown-menu')).toBeInTheDocument();
     });
 
-    it('비호스트: "내 예약 목록", "회원정보 변경", "호스트 등록하기", "로그아웃" 메뉴가 표시된다', async () => {
+    it('비호스트: "내 예약 목록", "회원정보 변경", "로그아웃" 메뉴가 표시된다', async () => {
         mockUseAuth.mockReturnValue({ data: nonHostUser });
         const user = userEvent.setup();
 
@@ -80,9 +80,11 @@ describe('ProfileDropdown', () => {
 
         expect(screen.getByTestId('menu-item-my-bookings')).toHaveTextContent('내 예약 목록');
         expect(screen.getByTestId('menu-item-settings')).toHaveTextContent('회원정보 변경');
-        expect(screen.getByTestId('menu-item-host-register')).toHaveTextContent('호스트 등록하기');
+        // 호스트 등록 임시 비활성화 (#479)
+        // expect(screen.getByTestId('menu-item-host-register')).toHaveTextContent('호스트 등록하기');
         expect(screen.getByTestId('menu-item-logout')).toHaveTextContent('로그아웃');
 
+        expect(screen.queryByTestId('menu-item-host-register')).not.toBeInTheDocument();
         expect(screen.queryByTestId('menu-item-host-profile-preview')).not.toBeInTheDocument();
         expect(screen.queryByTestId('menu-item-host-timeslots')).not.toBeInTheDocument();
         expect(screen.queryByTestId('menu-item-host-calendar')).not.toBeInTheDocument();

--- a/frontend/src/components/header/ProfileDropdown.tsx
+++ b/frontend/src/components/header/ProfileDropdown.tsx
@@ -75,6 +75,8 @@ export function ProfileDropdown() {
                                 호스트 설정
                             </DropdownMenuItem>
                         </>
+                    ) : null}
+                    {/* 호스트 등록 임시 비활성화 (#479)
                     ) : (
                         <DropdownMenuItem
                             data-testid="menu-item-host-register"
@@ -83,6 +85,7 @@ export function ProfileDropdown() {
                             호스트 등록하기
                         </DropdownMenuItem>
                     )}
+                    */}
 
                     <DropdownMenu.Separator className="h-px bg-gray-100 my-1" />
 


### PR DESCRIPTION
<img width="1280" height="720" alt="dropdown-no-host-register" src="https://github.com/user-attachments/assets/85c861ff-0dd3-45a3-b378-2c3946d6614c" />

## 🔗 관련 이슈
- Closes #479

---

## 📦 뭘 만들었나요? (What)

`ProfileDropdown`의 "호스트 등록하기" 메뉴 항목을 주석 처리하여 임시 비활성화.

- `ProfileDropdown.tsx`: 비호스트 사용자에게 보이던 메뉴 항목을 `null`로 대체하고 기존 코드 주석 처리
- `ProfileDropdown.test.tsx`: 관련 assertion 주석 처리 + "호스트 등록하기"가 표시되지 않음을 검증하는 assertion 추가

---

## 왜 이렇게 만들었나요? (Why)

호스트 등록 기능을 임시로 비활성화해야 하되, 추후 재활성화할 수 있도록 코드 삭제가 아닌 주석 처리로 진행. 라우트, 페이지, feature 코드는 모두 유지.

---

## 어떻게 테스트했나요? (Test)

단위 테스트 6/6 통과 (`pnpm test run src/components/header/ProfileDropdown.test.tsx`)

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 비호스트 사용자 드롭다운에서 "호스트 등록하기" 메뉴가 표시되지 않는지 확인
2. 호스트 사용자 드롭다운에서 기존 메뉴(내 프로필 미리보기, 시간대 설정, 호스트 설정)가 정상 표시되는지 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 호스트가 아닌 사용자의 프로필 드롭다운 메뉴에서 "호스트 등록하기" 항목이 더 이상 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->