### PR TITLE
feat: #444 Google AdSense Auto ads 적용

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,6 +29,10 @@ pnpm test
 pnpm lint
 ```
 
+## Google AdSense
+
+Google AdSense Auto ads is loaded globally from `index.html` with the publisher client script.
+
 ## 프로젝트 구조
 
 ```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,8 @@
     <meta property="og:description" content="호스트-게스트 간 미팅 예약 웹 서비스">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>cohi-chat</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9389330875359141"
+      crossorigin="anonymous"></script>
     <script type="module">
       if (import.meta.env.DEV) {
         import("react-grab");


### PR DESCRIPTION
﻿## 🔗 관련 이슈
- Closes #444

---

## 📦 뭘 만들었나요? (What)

- 프론트 `index.html`에 Google AdSense Auto ads 스크립트를 전역으로 추가했습니다.
- 홈 화면에 두려던 고정 광고 배너 방식 대신, AdSense가 위치를 자동으로 결정하는 방식으로 단순화했습니다.
- README에 현재 적용 방식이 Auto ads 스크립트 기반이라는 점을 반영했습니다.

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- 처음에는 홈 하단에 고정 배너를 넣는 ad unit 방식으로 구현했지만, 이 방식은 `data-ad-slot`과 별도 환경변수가 필요했습니다.
- 이슈 목표가 우선 "광고 붙이기" 자체에 있었기 때문에, 발급된 publisher client 스크립트만으로 바로 연결 가능한 Auto ads 방식이 초기 적용 비용이 더 낮았습니다.
- 이후 실제 광고 배치 제어가 필요해지면 그때 ad unit 방식으로 확장하는 편이 관리하기 쉽다고 판단했습니다.

---

## 어떻게 테스트했나요? (Test)

- `cd frontend && pnpm lint`
- `cd frontend && pnpm test -- --run`
- 로컬 프론트 개발 서버(`http://localhost:3001`)에서 AdSense 스크립트가 `index.html`에 주입되는 것 확인

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 홈 화면 진입 후 애플리케이션이 정상 렌더링되는지 확인
2. 브라우저 개발자도구에서 AdSense 스크립트가 head에 포함되는지 확인
3. 테스트 및 린트가 통과하는지 확인

</details>

---

## 참고사항 / 회고 메모 (Notes)

- Auto ads는 스크립트만 삽입한 상태라 `localhost`에서 실제 광고가 바로 보이지 않을 수 있습니다.
- 실제 광고 노출은 공개 도메인 연결 및 AdSense 승인 상태에 영향을 받습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Google AdSense 광고 지원이 추가되었습니다. 광고가 앱 전체에서 자동으로 로드되고 표시됩니다.

* **문서**
  * Google AdSense 구성에 대한 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->