### PR TITLE
fix: #504 CC worktree 에서 lint hook 이 작동 안되는 현상 고침

### DIFF
--- a/.claude/hooks/post-file-change.sh
+++ b/.claude/hooks/post-file-change.sh
@@ -15,8 +15,8 @@ except Exception:
 
 [ -z "$FILE_PATH" ] && exit 0
 
-ROOT_DIR="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null)}"
-ROOT_DIR="${ROOT_DIR:-$(pwd)}"
+ROOT_DIR="$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null)"
+ROOT_DIR="${ROOT_DIR:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 NORMALIZED_PATH="${FILE_PATH//\\//}"
 
 if [[ "$NORMALIZED_PATH" == frontend/* || "$NORMALIZED_PATH" == */frontend/* ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # Claude Code
 .claude/settings.local.json
 .claude/issue/
+.claude/worktrees/
 
 # 이슈 관련
 ./issues


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #504

---

## 📦 뭘 만들었나요? (What)

- `post-file-change.sh` hook이 worktree에서 파일 편집 시 올바른 프로젝트 루트를 찾도록 수정
- `.claude/worktrees/` 디렉토리를 `.gitignore`에 추가

---

## 왜 이렇게 만들었나요? (Why)

기존에는 `CLAUDE_PROJECT_DIR` 환경변수를 우선 사용하여 프로젝트 루트를 결정했는데, worktree 내 파일 편집 시 이 변수가 메인 프로젝트 루트를 가리켜서 `node_modules`를 찾지 못하는 문제가 있었습니다.

`FILE_PATH` 기준으로 `git rev-parse --show-toplevel`을 먼저 시도하고, 실패 시에만 `CLAUDE_PROJECT_DIR`로 fallback하도록 우선순위를 변경했습니다.

---

## 어떻게 테스트했나요? (Test)

worktree(`bc_480`)에서 frontend 파일 편집 시 hook이 정상적으로 해당 worktree의 `frontend/`에서 lint를 실행하는 것을 확인

---

## 참고사항 / 회고 메모 (Notes)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 프로젝트 근본 디렉토리 해석 로직이 조정되었습니다.
  * 개발 환경 설정이 개선되었습니다.

**참고**: 이번 업데이트는 주로 내부 개발 인프라 개선사항을 포함하며, 사용자 환경에는 직접적인 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->