### PR TITLE
fix: #91 배포 실패 핫픽스 - redis 기동 로직 복구

### DIFF
--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -16,6 +16,9 @@ source "$(dirname "$0")/blue-green-common.sh"
 main() {
     print_banner "Blue-Green Deploy Start"
 
+    echo "[infra] Ensuring redis is running..."
+    $COMPOSE up -d redis
+
     local active
     active=$(detect_active)
     local inactive


### PR DESCRIPTION
## 🔗 관련 이슈
- #91

---

## 📦 뭘 만들었나요? (What)

배포 실패 핫픽스 — `blue-green-deploy.sh`에서 redis `up -d` 로직 복구

---

## 왜 이렇게 만들었나요? (Why)

코드리뷰 반영 중 `$COMPOSE up -d redis`를 통째로 제거했는데, redis가 미기동 상태일 때 배포하면 `backend-green`이 redis 의존성을 못 찾아 헬스체크 120s 초과로 배포 실패.

`up -d redis`는 이미 떠 있으면 no-op이므로 복구. `wait_healthy`만 제거 유지.

---

## 어떻게 테스트했나요? (Test)

N/A

---

## 참고사항 / 회고 메모 (Notes)

배포 실패 긴급 복구용 PR