### PR TITLE
fix: reconnect nginx to active backend network

### DIFF
--- a/infra/app/docker-compose.server.yml
+++ b/infra/app/docker-compose.server.yml
@@ -68,8 +68,10 @@ services:
 
 networks:
   cohi-chat-network:
+    name: cohi-chat-app
     driver: bridge
 
 volumes:
   redis-data:
     driver: local
+

--- a/scripts/blue-green-common.sh
+++ b/scripts/blue-green-common.sh
@@ -3,6 +3,7 @@
 
 readonly COMPOSE="${COMPOSE:-docker-compose -p cohi-chat --env-file .env -f infra/app/docker-compose.server.yml -f infra/observability/docker-compose.backend-observability.yml}"
 readonly NGINX_UPSTREAM_FILE="${NGINX_UPSTREAM_FILE:-./infra/app/nginx/upstream.conf}"
+readonly APP_NETWORK_NAME="${APP_NETWORK_NAME:-cohi-chat-app}"
 readonly HEALTH_INTERVAL="${HEALTH_INTERVAL:-5}"
 readonly DRAIN_DELAY_SECONDS="${DRAIN_DELAY_SECONDS:-15}"
 
@@ -95,15 +96,21 @@ container_running() {
     [ "$state" = "running" ]
 }
 
-container_networks() {
-    local name=$1
-    docker inspect --format='{{range $k, $v := .NetworkSettings.Networks}}{{println $k}}{{end}}' "$name" 2>/dev/null || true
-}
-
 container_on_network() {
     local name=$1
     local network=$2
-    container_networks "$name" | grep -Fxq "$network"
+    docker inspect --format='{{range $k, $v := .NetworkSettings.Networks}}{{println $k}}{{end}}' "$name" 2>/dev/null | grep -Fxq "$network"
+}
+
+ensure_container_on_app_network() {
+    local name=$1
+
+    if container_on_network "$name" "$APP_NETWORK_NAME"; then
+        return 0
+    fi
+
+    echo "[network] Connecting ${name} to ${APP_NETWORK_NAME}..."
+    docker network connect "$APP_NETWORK_NAME" "$name"
 }
 
 ensure_nginx_running() {
@@ -112,24 +119,10 @@ ensure_nginx_running() {
 
     if [ "$nginx_status" != "running" ]; then
         echo "[nginx] Starting nginx..."
-        $COMPOSE up -d nginx
+        $COMPOSE up -d --no-deps nginx
     fi
-}
 
-ensure_shared_network() {
-    local source_container=$1
-    local target_container=$2
-
-    while IFS= read -r network; do
-        [ -n "$network" ] || continue
-
-        if container_on_network "$target_container" "$network"; then
-            continue
-        fi
-
-        echo "[network] Connecting ${target_container} to ${network} for ${source_container}..."
-        docker network connect "$network" "$target_container"
-    done < <(container_networks "$source_container")
+    ensure_container_on_app_network "cohi-chat-nginx"
 }
 
 stop_backend_if_running() {

--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -31,7 +31,6 @@ main() {
 
     wait_healthy "cohi-chat-backend-${inactive}" "backend-${inactive}"
     ensure_nginx_running
-    ensure_shared_network "cohi-chat-backend-${inactive}" "cohi-chat-nginx"
     switch_upstream "$inactive"
 
     stop_backend_if_running "$active" "old"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -20,17 +20,11 @@ main() {
 
     echo "[info] Active: ${active} -> Rolling back to: ${previous}"
 
-    if container_running "$previous"; then
-        echo "[info] backend-${previous} is already running. Waiting for health."
-        wait_healthy "cohi-chat-backend-${previous}" "backend-${previous}"
-    else
-        echo "[info] backend-${previous} is stopped. Starting it..."
-        $COMPOSE start "backend-${previous}"
-        wait_healthy "cohi-chat-backend-${previous}" "backend-${previous}"
-    fi
+    echo "[rollback] Recreating backend-${previous} with current compose network settings..."
+    $COMPOSE up -d --no-deps "backend-${previous}"
+    wait_healthy "cohi-chat-backend-${previous}" "backend-${previous}"
 
     ensure_nginx_running
-    ensure_shared_network "cohi-chat-backend-${previous}" "cohi-chat-nginx"
     switch_upstream "$previous"
 
     stop_backend_if_running "$active" "problematic"


### PR DESCRIPTION
﻿## 🔗 관련 이슈
- 해당 없음 (운영 502 핫픽스)

---

## 📦 뭘 만들었나요? (What)

블루-그린 배포/롤백이 항상 같은 앱 Docker 네트워크를 기준으로 동작하도록 정리했습니다.

- 앱 compose 네트워크 이름을 `cohi-chat-app`으로 고정
- `nginx`가 실행 중이어도 `cohi-chat-app` 네트워크에 연결되어 있는지 확인
- upstream 전환은 앱 네트워크 기준으로만 수행
- rollback은 `start` 대신 `up -d --no-deps`로 이전 backend를 현재 compose 네트워크 설정으로 다시 띄우도록 변경

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

운영 중 502 원인을 확인해 보니 Spring 애플리케이션 자체가 아니라, 오래 살아 있던 `nginx` 컨테이너가 새로 뜬 backend 컨테이너와 같은 Docker 네트워크를 보지 못해 `backend-blue`/`backend-green` 이름 해석이 깨지는 문제가 반복되고 있었습니다.

이번 수정에서는 앱 컨테이너들이 바라보는 네트워크를 `cohi-chat-app`으로 고정하고, deploy/rollback 시 `nginx`와 backend가 그 네트워크를 공유한다는 전제를 명시적으로 보장하도록 정리했습니다.

---

## 어떻게 테스트했나요? (Test)

운영 로그(`host not found in upstream`, `Host is unreachable`)를 기준으로 재현 원인을 배포 스크립트 흐름과 대조했습니다.

`bash -n` 문법 검증이나 실제 deploy script 실행 검증은 현재 Codex 실행 환경의 Bash/WSL 접근 제한 때문에 수행하지 못했습니다.

<details>
<summary>테스트 시나리오 (선택)</summary>

1. 운영 로그에서 `host not found in upstream` / `Host is unreachable` 패턴 확인
2. nginx가 오래 살아 있는 상태에서 새 backend 컨테이너가 다른 Docker 네트워크에 붙을 수 있는 흐름 확인
3. 앱 compose 네트워크를 고정하고 nginx/rollback 경로를 그 네트워크 기준으로 수정

</details>

---

## 참고사항 / 회고 메모 (Notes)

운영 이슈 대응 성격이라 기존 hotfix 브랜치와 분리해 `khs_hotfix_502_network` 브랜치로 따로 정리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 네트워크 관리 기능 추가로 컨테이너 연결 안정성 강화
  * 배포 스크립트의 롤백 프로세스 개선 및 일관성 향상
  * Docker Compose 네트워크 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->