### PR TITLE
[HOTFIX] 채팅 서버 Dockerfile 빌드 실패 수정

### DIFF
--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -8,9 +8,11 @@ FROM base AS builder
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN --mount=type=cache,id=chat-pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    pnpm install --frozen-lockfile --ignore-scripts
 COPY . .
-RUN pnpm run build && pnpm prune --prod
+RUN pnpm run postinstall --if-present \
+    && pnpm run build \
+    && pnpm prune --prod
 
 FROM node:22-alpine AS runtime
 WORKDIR /app


### PR DESCRIPTION
## 🔗 관련 이슈
- N/A (merged PR #528 후속 hotfix)

---

## 📦 뭘 만들었나요? (What)

- 채팅 서버 Docker image 빌드 시 `pnpm install` 단계에서 `postinstall -> prisma generate`가 너무 일찍 실행되던 문제를 수정했습니다.
- `chat/Dockerfile`에서 install 단계는 `--ignore-scripts`로 수행하고, 전체 소스를 복사한 뒤 `postinstall`을 실행하도록 순서를 조정했습니다.

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- PR #528이 머지된 뒤 GitHub Actions 빌드에서 `Could not find Prisma Schema`로 실패했습니다.
- 원인은 `pnpm install --frozen-lockfile`가 root `postinstall`을 바로 실행하면서 `prisma generate`가 schema 복사 전 시점에 돌았기 때문입니다.
- 따라서 install 단계에서는 스크립트를 막고, `COPY . .` 이후 필요한 파일이 모두 들어온 상태에서 `postinstall`을 실행하도록 바꾸는 것이 가장 작은 수정으로 빌드 실패를 해소하는 방법이라고 판단했습니다.

---

## 어떻게 테스트했나요? (Test)

- 로그 기준 실패 원인 확인: `Could not find Prisma Schema`
- `chat/Dockerfile` 빌드 단계 순서 재검토

<details>
<summary>테스트 시나리오 (선택)</summary>

1. `pnpm install --frozen-lockfile --ignore-scripts`로 install 단계에서 schema 의존 postinstall이 실행되지 않음을 확인
2. `COPY . .` 이후 `pnpm run postinstall --if-present`가 실행되도록 조정
3. 이후 `pnpm run build && pnpm prune --prod` 순서로 기존 산출물 흐름을 유지

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 이번 PR은 `#528` 머지 이후 발생한 채팅 서버 image build 실패만 최소 범위로 수정한 후속 hotfix입니다.
- 변경 범위는 `chat/Dockerfile` 1개 파일입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 프로세스의 의존성 설치 단계 및 스크립트 실행 순서를 최적화했습니다.

---

*이번 릴리스는 내부 빌드 인프라 개선만 포함하며, 사용자 기능에는 영향을 주지 않습니다.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->