### PR TITLE
[HOTFIX] 채팅 서버 Dockerfile build 단계 정정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,22 @@ jobs:
         run: |
           cd frontend
           pnpm build
+
+  chat:
+    name: Chat Docker Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build chat server image
+        run: |
+          docker buildx build \
+            --file chat/Dockerfile \
+            --tag cohi-chat-chat-server:ci \
+            --load \
+            ./chat

--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -10,7 +10,8 @@ COPY package.json pnpm-lock.yaml ./
 RUN --mount=type=cache,id=chat-pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile --ignore-scripts
 COPY . .
-RUN pnpm run build \
+RUN pnpm run prisma:generate \
+    && pnpm run build \
     && pnpm prune --prod
 
 FROM node:22-alpine AS runtime

--- a/chat/package.json
+++ b/chat/package.json
@@ -6,9 +6,9 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "build": "pnpm run prisma:generate && nest build",
+    "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "postinstall": "prisma generate",
+    "postinstall": "pnpm run prisma:generate",
     "prisma:generate": "prisma generate",
     "start": "nest start",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
## 🔗 관련 이슈
- N/A (`#530` 후속 hotfix)

---

## 📦 뭘 만들었나요? (What)

- `chat/Dockerfile`에서 `prisma generate`를 Docker build 단계에서 명시적으로 호출하도록 정리했습니다.
- `chat/package.json`에서 `build`는 `nest build`만 수행하게 하고, `postinstall`은 `pnpm run prisma:generate`로 분리해 책임을 명확히 했습니다.
- PR CI에 `Chat Docker Build` job을 추가해서, 앞으로는 `chat/Dockerfile`이 머지 전에 실제로 빌드되는지 검증하도록 했습니다.

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

- `#530` 머지 후 `main`의 채팅 배포 런이 다시 실패했고, 원인은 Dockerfile 안 `pnpm run postinstall --if-present` 문법 오류였습니다.
- 근본적으로는 `chat` 변경이 PR CI에서 전혀 검증되지 않아, Dockerfile 문제를 머지 후에야 발견한 것이 반복 원인이었습니다.
- 그래서 이번에는 단순 문법 수정에서 끝내지 않고, `Prisma generate 호출 위치를 명확히 정리`하고 `chat Docker build 자체를 PR CI에 추가`해 재발 경로를 같이 막았습니다.

---

## 어떻게 테스트했나요? (Test)

- `cd chat && pnpm install --frozen-lockfile`
- `cd chat && pnpm run prisma:generate`
- `cd chat && pnpm build`

<details>
<summary>테스트 시나리오 (선택)</summary>

1. install 시 `postinstall -> prisma generate`가 정상 동작하는지 확인
2. `prisma generate` 명령이 schema 기준으로 통과하는지 확인
3. `build`가 `nest build`만 수행하도록 바뀐 뒤에도 정상 통과하는지 확인
4. PR CI에서 `chat/Dockerfile` 자체를 빌드하도록 워크플로를 추가해, 동일 회귀를 머지 전에 차단

</details>

---

## 참고사항 / 회고 메모 (Notes)

- 이번 PR은 이미 머지된 `#530` 이후 남아 있던 채팅 Dockerfile/build 검증 누락 문제를 같이 정리하는 후속 hotfix입니다.
- 변경 범위는 `chat/package.json`, `chat/Dockerfile`, `.github/workflows/ci.yml` 3개 파일입니다.