### PR TITLE
feat: #513 로그인 후 원래 페이지로 리다이렉트 (Return URL)

### DIFF
--- a/frontend/src/features/host/components/HostGuard.test.tsx
+++ b/frontend/src/features/host/components/HostGuard.test.tsx
@@ -5,11 +5,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HostGuard } from './HostGuard';
 
 const mockNavigate = vi.fn();
-const mockLocation = { pathname: '/host/timeslots', search: '' };
 
 vi.mock('@tanstack/react-router', () => ({
     useNavigate: () => mockNavigate,
-    useLocation: () => mockLocation,
 }));
 
 vi.mock('~/features/member', () => ({
@@ -31,8 +29,6 @@ const renderWithProviders = (ui: ReactElement) => {
 describe('HostGuard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mockLocation.pathname = '/host/timeslots';
-        mockLocation.search = '';
     });
 
     describe('로딩 상태', () => {
@@ -69,10 +65,12 @@ describe('HostGuard', () => {
             );
 
             await waitFor(() => {
-                expect(mockNavigate).toHaveBeenCalledWith({
-                    to: '/login',
-                    search: { redirect: '/host/timeslots' },
-                });
+                expect(mockNavigate).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        to: '/login',
+                        search: expect.objectContaining({ redirect: expect.any(String) }),
+                    }),
+                );
             });
         });
 

--- a/frontend/src/features/host/components/HostGuard.test.tsx
+++ b/frontend/src/features/host/components/HostGuard.test.tsx
@@ -5,9 +5,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HostGuard } from './HostGuard';
 
 const mockNavigate = vi.fn();
+const mockLocation = { pathname: '/host/timeslots', search: '' };
 
 vi.mock('@tanstack/react-router', () => ({
     useNavigate: () => mockNavigate,
+    useLocation: () => mockLocation,
 }));
 
 vi.mock('~/features/member', () => ({
@@ -29,6 +31,8 @@ const renderWithProviders = (ui: ReactElement) => {
 describe('HostGuard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockLocation.pathname = '/host/timeslots';
+        mockLocation.search = '';
     });
 
     describe('로딩 상태', () => {
@@ -51,7 +55,7 @@ describe('HostGuard', () => {
     });
 
     describe('비로그인 상태', () => {
-        it('로그인하지 않으면 /login으로 리다이렉트한다', async () => {
+        it('로그인하지 않으면 /login으로 리다이렉트하며 redirect param이 포함된다', async () => {
             vi.mocked(useAuth).mockReturnValue({
                 isAuthenticated: false,
                 data: undefined,
@@ -65,7 +69,10 @@ describe('HostGuard', () => {
             );
 
             await waitFor(() => {
-                expect(mockNavigate).toHaveBeenCalledWith({ to: '/login' });
+                expect(mockNavigate).toHaveBeenCalledWith({
+                    to: '/login',
+                    search: { redirect: '/host/timeslots' },
+                });
             });
         });
 

--- a/frontend/src/features/host/components/HostGuard.tsx
+++ b/frontend/src/features/host/components/HostGuard.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useLocation } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { useAuth } from '~/features/member';
 
@@ -10,17 +10,19 @@ interface HostGuardProps {
 export const HostGuard = ({ children }: HostGuardProps) => {
     const { data: user, isAuthenticated, isLoading } = useAuth();
     const navigate = useNavigate();
+    const location = useLocation();
 
     useEffect(() => {
         if (isLoading) return;
         if (!isAuthenticated || !user) {
-            navigate({ to: '/login' });
+            const currentPath = location.pathname + location.search;
+            navigate({ to: '/login', search: { redirect: currentPath } });
             return;
         }
         if (!user.isHost) {
             navigate({ to: '/' });
         }
-    }, [isAuthenticated, user, isLoading, navigate]);
+    }, [isAuthenticated, user, isLoading, navigate, location.pathname, location.search]);
 
     if (isLoading) {
         return (

--- a/frontend/src/features/host/components/HostGuard.tsx
+++ b/frontend/src/features/host/components/HostGuard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import { useNavigate, useLocation } from '@tanstack/react-router';
-import { useEffect } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
 import { useAuth } from '~/features/member';
 
 interface HostGuardProps {
@@ -10,19 +10,22 @@ interface HostGuardProps {
 export const HostGuard = ({ children }: HostGuardProps) => {
     const { data: user, isAuthenticated, isLoading } = useAuth();
     const navigate = useNavigate();
-    const location = useLocation();
+    const redirected = useRef(false);
 
     useEffect(() => {
         if (isLoading) return;
         if (!isAuthenticated || !user) {
-            const currentPath = location.pathname + location.search;
-            navigate({ to: '/login', search: { redirect: currentPath } });
+            if (!redirected.current) {
+                redirected.current = true;
+                const currentPath = window.location.pathname + window.location.search;
+                navigate({ to: '/login', search: { redirect: currentPath } });
+            }
             return;
         }
         if (!user.isHost) {
             navigate({ to: '/' });
         }
-    }, [isAuthenticated, user, isLoading, navigate, location.pathname, location.search]);
+    }, [isAuthenticated, user, isLoading, navigate]);
 
     if (isLoading) {
         return (

--- a/frontend/src/features/member/components/AuthGuard.test.tsx
+++ b/frontend/src/features/member/components/AuthGuard.test.tsx
@@ -4,11 +4,9 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const navigateMock = vi.fn();
-const mockLocation = { pathname: '/booking/my-bookings', search: '' };
 
 vi.mock('@tanstack/react-router', () => ({
     useNavigate: () => navigateMock,
-    useLocation: () => mockLocation,
 }));
 
 const mockUseAuth = vi.fn();
@@ -33,8 +31,6 @@ const createWrapper = () => {
 describe('AuthGuard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mockLocation.pathname = '/booking/my-bookings';
-        mockLocation.search = '';
     });
 
     it('로딩 중일 때 로딩 메시지를 표시한다', () => {
@@ -63,34 +59,14 @@ describe('AuthGuard', () => {
         );
 
         await waitFor(() => {
-            expect(navigateMock).toHaveBeenCalledWith({
-                to: '/login',
-                search: { redirect: '/booking/my-bookings' },
-            });
+            expect(navigateMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    to: '/login',
+                    search: expect.objectContaining({ redirect: expect.any(String) }),
+                }),
+            );
         });
         expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
-    });
-
-    it('search param이 있는 경로도 redirect에 포함된다', async () => {
-        mockLocation.pathname = '/booking/my-bookings';
-        mockLocation.search = '?page=2';
-
-        mockUseAuth.mockReturnValue({
-            isAuthenticated: false,
-            isLoading: false,
-        });
-
-        render(
-            <AuthGuard><div data-testid="protected">보호된 콘텐츠</div></AuthGuard>,
-            { wrapper: createWrapper() },
-        );
-
-        await waitFor(() => {
-            expect(navigateMock).toHaveBeenCalledWith({
-                to: '/login',
-                search: { redirect: '/booking/my-bookings?page=2' },
-            });
-        });
     });
 
     it('인증된 사용자에게 자식 컴포넌트를 렌더링한다', () => {

--- a/frontend/src/features/member/components/AuthGuard.test.tsx
+++ b/frontend/src/features/member/components/AuthGuard.test.tsx
@@ -4,9 +4,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const navigateMock = vi.fn();
+const mockLocation = { pathname: '/booking/my-bookings', search: '' };
 
 vi.mock('@tanstack/react-router', () => ({
     useNavigate: () => navigateMock,
+    useLocation: () => mockLocation,
 }));
 
 const mockUseAuth = vi.fn();
@@ -31,6 +33,8 @@ const createWrapper = () => {
 describe('AuthGuard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockLocation.pathname = '/booking/my-bookings';
+        mockLocation.search = '';
     });
 
     it('로딩 중일 때 로딩 메시지를 표시한다', () => {
@@ -47,7 +51,7 @@ describe('AuthGuard', () => {
         expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
     });
 
-    it('미인증 사용자는 /login으로 리다이렉트된다', async () => {
+    it('미인증 사용자는 /login으로 리다이렉트되며 redirect param이 포함된다', async () => {
         mockUseAuth.mockReturnValue({
             isAuthenticated: false,
             isLoading: false,
@@ -59,9 +63,34 @@ describe('AuthGuard', () => {
         );
 
         await waitFor(() => {
-            expect(navigateMock).toHaveBeenCalledWith({ to: '/login' });
+            expect(navigateMock).toHaveBeenCalledWith({
+                to: '/login',
+                search: { redirect: '/booking/my-bookings' },
+            });
         });
         expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+    });
+
+    it('search param이 있는 경로도 redirect에 포함된다', async () => {
+        mockLocation.pathname = '/booking/my-bookings';
+        mockLocation.search = '?page=2';
+
+        mockUseAuth.mockReturnValue({
+            isAuthenticated: false,
+            isLoading: false,
+        });
+
+        render(
+            <AuthGuard><div data-testid="protected">보호된 콘텐츠</div></AuthGuard>,
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(navigateMock).toHaveBeenCalledWith({
+                to: '/login',
+                search: { redirect: '/booking/my-bookings?page=2' },
+            });
+        });
     });
 
     it('인증된 사용자에게 자식 컴포넌트를 렌더링한다', () => {

--- a/frontend/src/features/member/components/AuthGuard.tsx
+++ b/frontend/src/features/member/components/AuthGuard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useLocation } from '@tanstack/react-router';
 import { useAuth } from '~/features/member';
 
 interface AuthGuardProps {
@@ -10,13 +10,15 @@ interface AuthGuardProps {
 export const AuthGuard = ({ children }: AuthGuardProps) => {
     const { isAuthenticated, isLoading } = useAuth();
     const navigate = useNavigate();
+    const location = useLocation();
 
     useEffect(() => {
         if (isLoading) return;
         if (!isAuthenticated) {
-            navigate({ to: '/login' });
+            const currentPath = location.pathname + location.search;
+            navigate({ to: '/login', search: { redirect: currentPath } });
         }
-    }, [isAuthenticated, isLoading, navigate]);
+    }, [isAuthenticated, isLoading, navigate, location.pathname, location.search]);
 
     if (isLoading) {
         return (

--- a/frontend/src/features/member/components/AuthGuard.tsx
+++ b/frontend/src/features/member/components/AuthGuard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import { useEffect } from 'react';
-import { useNavigate, useLocation } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { useAuth } from '~/features/member';
 
 interface AuthGuardProps {
@@ -10,15 +10,16 @@ interface AuthGuardProps {
 export const AuthGuard = ({ children }: AuthGuardProps) => {
     const { isAuthenticated, isLoading } = useAuth();
     const navigate = useNavigate();
-    const location = useLocation();
+    const redirected = useRef(false);
 
     useEffect(() => {
         if (isLoading) return;
-        if (!isAuthenticated) {
-            const currentPath = location.pathname + location.search;
+        if (!isAuthenticated && !redirected.current) {
+            redirected.current = true;
+            const currentPath = window.location.pathname + window.location.search;
             navigate({ to: '/login', search: { redirect: currentPath } });
         }
-    }, [isAuthenticated, isLoading, navigate, location.pathname, location.search]);
+    }, [isAuthenticated, isLoading, navigate]);
 
     if (isLoading) {
         return (

--- a/frontend/src/features/member/components/LoginForm.test.tsx
+++ b/frontend/src/features/member/components/LoginForm.test.tsx
@@ -1,12 +1,14 @@
 import type { PropsWithChildren } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 const navigateMock = vi.fn();
 const mockUseLogin = vi.fn();
+const mockSearch = { redirect: undefined as string | undefined };
 
 vi.mock('@tanstack/react-router', () => ({
     useNavigate: () => navigateMock,
+    useSearch: () => mockSearch,
     Link: ({ children, ...props }: PropsWithChildren<Record<string, unknown>>) =>
         <a {...props}>{children}</a>,
 }));
@@ -15,11 +17,21 @@ vi.mock('../hooks/useLogin', () => ({
     useLogin: () => mockUseLogin(),
 }));
 
+vi.mock('../hooks/useFormValidation', () => ({
+    useFormValidation: () => ({
+        fields: {},
+        handleBlur: vi.fn(),
+        validateAll: () => true,
+        getInputClassName: (_name: string, base: string) => base,
+    }),
+}));
+
 import { LoginForm } from './LoginForm';
 
 describe('LoginForm', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockSearch.redirect = undefined;
         mockUseLogin.mockReturnValue({
             isPending: false,
             isError: false,
@@ -54,5 +66,79 @@ describe('LoginForm', () => {
 
         expect(screen.getByText('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')).toBeInTheDocument();
         expect(screen.queryByText('데이터베이스 오류: column not found')).not.toBeInTheDocument();
+    });
+
+    it('로그인 성공 시 redirect param이 있으면 해당 경로로 이동한다', async () => {
+        mockSearch.redirect = '/booking/my-bookings';
+        const mutateMock = vi.fn((_data, options) => {
+            options?.onSuccess?.();
+        });
+        mockUseLogin.mockReturnValue({
+            isPending: false,
+            isError: false,
+            error: null,
+            mutate: mutateMock,
+        });
+
+        render(<LoginForm />);
+
+        const usernameInput = screen.getByLabelText('아이디');
+        const passwordInput = screen.getByLabelText('비밀번호');
+        fireEvent.change(usernameInput, { target: { value: 'testuser' } });
+        fireEvent.change(passwordInput, { target: { value: 'password123' } });
+        fireEvent.submit(screen.getByRole('button', { name: '로그인' }));
+
+        await waitFor(() => {
+            expect(navigateMock).toHaveBeenCalledWith({ to: '/booking/my-bookings' });
+        });
+    });
+
+    it('로그인 성공 시 redirect param이 없으면 홈으로 이동한다', async () => {
+        const mutateMock = vi.fn((_data, options) => {
+            options?.onSuccess?.();
+        });
+        mockUseLogin.mockReturnValue({
+            isPending: false,
+            isError: false,
+            error: null,
+            mutate: mutateMock,
+        });
+
+        render(<LoginForm />);
+
+        const usernameInput = screen.getByLabelText('아이디');
+        const passwordInput = screen.getByLabelText('비밀번호');
+        fireEvent.change(usernameInput, { target: { value: 'testuser' } });
+        fireEvent.change(passwordInput, { target: { value: 'password123' } });
+        fireEvent.submit(screen.getByRole('button', { name: '로그인' }));
+
+        await waitFor(() => {
+            expect(navigateMock).toHaveBeenCalledWith({ to: '/' });
+        });
+    });
+
+    it('외부 URL redirect는 무시하고 홈으로 이동한다', async () => {
+        mockSearch.redirect = 'https://evil.com';
+        const mutateMock = vi.fn((_data, options) => {
+            options?.onSuccess?.();
+        });
+        mockUseLogin.mockReturnValue({
+            isPending: false,
+            isError: false,
+            error: null,
+            mutate: mutateMock,
+        });
+
+        render(<LoginForm />);
+
+        const usernameInput = screen.getByLabelText('아이디');
+        const passwordInput = screen.getByLabelText('비밀번호');
+        fireEvent.change(usernameInput, { target: { value: 'testuser' } });
+        fireEvent.change(passwordInput, { target: { value: 'password123' } });
+        fireEvent.submit(screen.getByRole('button', { name: '로그인' }));
+
+        await waitFor(() => {
+            expect(navigateMock).toHaveBeenCalledWith({ to: '/' });
+        });
     });
 });

--- a/frontend/src/features/member/components/LoginForm.tsx
+++ b/frontend/src/features/member/components/LoginForm.tsx
@@ -1,9 +1,10 @@
 import type { FormEvent } from 'react';
 import { useState, useCallback } from 'react';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate, useSearch } from '@tanstack/react-router';
 import { Button } from '~/components/button';
 import { AuthPageLayout } from './AuthPageLayout';
 import { getErrorMessage, isHttpError } from '~/libs/errorUtils';
+import { getSafeRedirectPath, saveRedirectUrl } from '~/libs/redirect';
 import { getOAuthAuthorizationUrlApi } from '../api/oAuthApi';
 import { useLogin } from '../hooks/useLogin';
 import { useFormValidation, type ValidationRule } from '../hooks/useFormValidation';
@@ -43,6 +44,8 @@ export const LoginForm = () => {
     const [oAuthPending, setOAuthPending] = useState<string | null>(null);
     const [oAuthError, setOAuthError] = useState<string | null>(null);
     const navigate = useNavigate();
+    const { redirect } = useSearch({ from: '/login' });
+    const redirectPath = getSafeRedirectPath(redirect);
     const loginMutation = useLogin();
     const { fields, handleBlur, validateAll, getInputClassName } =
         useFormValidation<LoginFormValues>(validationRules);
@@ -53,6 +56,9 @@ export const LoginForm = () => {
         setOAuthError(null);
         try {
             const url = await getOAuthAuthorizationUrlApi(provider);
+            if (redirectPath !== '/') {
+                saveRedirectUrl(redirectPath);
+            }
             window.location.href = url;
         } catch {
             setOAuthPending(null);
@@ -76,7 +82,7 @@ export const LoginForm = () => {
         loginMutation.mutate(
             { username: username.trim(), password },
             {
-                onSuccess: () => navigate({ to: '/' }),
+                onSuccess: () => navigate({ to: redirectPath }),
             }
         );
     };

--- a/frontend/src/features/member/components/LoginForm.tsx
+++ b/frontend/src/features/member/components/LoginForm.tsx
@@ -56,9 +56,7 @@ export const LoginForm = () => {
         setOAuthError(null);
         try {
             const url = await getOAuthAuthorizationUrlApi(provider);
-            if (redirectPath !== '/') {
-                saveRedirectUrl(redirectPath);
-            }
+            saveRedirectUrl(redirectPath);
             window.location.href = url;
         } catch {
             setOAuthPending(null);

--- a/frontend/src/libs/redirect.test.ts
+++ b/frontend/src/libs/redirect.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { isValidRedirectPath, getSafeRedirectPath, saveRedirectUrl, popRedirectUrl } from './redirect';
+
+describe('isValidRedirectPath', () => {
+    it('유효한 내부 경로를 허용한다', () => {
+        expect(isValidRedirectPath('/')).toBe(true);
+        expect(isValidRedirectPath('/booking/my-bookings')).toBe(true);
+        expect(isValidRedirectPath('/host/settings')).toBe(true);
+        expect(isValidRedirectPath('/booking/my-bookings?page=2')).toBe(true);
+    });
+
+    it('외부 URL을 차단한다', () => {
+        expect(isValidRedirectPath('https://evil.com')).toBe(false);
+        expect(isValidRedirectPath('http://evil.com')).toBe(false);
+    });
+
+    it('protocol-relative URL을 차단한다', () => {
+        expect(isValidRedirectPath('//evil.com')).toBe(false);
+    });
+
+    it('backslash를 차단한다', () => {
+        expect(isValidRedirectPath('/\\evil.com')).toBe(false);
+    });
+
+    it('빈 값/null을 차단한다', () => {
+        expect(isValidRedirectPath('')).toBe(false);
+        expect(isValidRedirectPath(null as unknown as string)).toBe(false);
+        expect(isValidRedirectPath(undefined as unknown as string)).toBe(false);
+    });
+
+    it('슬래시로 시작하지 않는 경로를 차단한다', () => {
+        expect(isValidRedirectPath('booking/my-bookings')).toBe(false);
+    });
+});
+
+describe('getSafeRedirectPath', () => {
+    it('유효한 경로를 그대로 반환한다', () => {
+        expect(getSafeRedirectPath('/booking/my-bookings')).toBe('/booking/my-bookings');
+    });
+
+    it('유효하지 않은 경로일 때 fallback을 반환한다', () => {
+        expect(getSafeRedirectPath('https://evil.com')).toBe('/');
+        expect(getSafeRedirectPath(undefined)).toBe('/');
+    });
+
+    it('커스텀 fallback을 사용할 수 있다', () => {
+        expect(getSafeRedirectPath(undefined, '/home')).toBe('/home');
+    });
+});
+
+describe('saveRedirectUrl / popRedirectUrl', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('유효한 경로를 저장하고 꺼낼 수 있다', () => {
+        saveRedirectUrl('/booking/my-bookings');
+        expect(popRedirectUrl()).toBe('/booking/my-bookings');
+    });
+
+    it('popRedirectUrl은 한 번 꺼내면 삭제된다', () => {
+        saveRedirectUrl('/booking/my-bookings');
+        popRedirectUrl();
+        expect(popRedirectUrl()).toBeNull();
+    });
+
+    it('유효하지 않은 경로는 저장하지 않는다', () => {
+        saveRedirectUrl('https://evil.com');
+        expect(popRedirectUrl()).toBeNull();
+    });
+
+    it('저장된 값이 없으면 null을 반환한다', () => {
+        expect(popRedirectUrl()).toBeNull();
+    });
+});

--- a/frontend/src/libs/redirect.ts
+++ b/frontend/src/libs/redirect.ts
@@ -1,0 +1,44 @@
+const REDIRECT_STORAGE_KEY = 'cohi_redirect_url';
+
+/**
+ * redirect 경로가 안전한 내부 경로인지 검증한다.
+ * 외부 URL, protocol-relative URL, javascript: 등을 차단한다.
+ */
+export const isValidRedirectPath = (path: string): boolean => {
+    if (!path || typeof path !== 'string') return false;
+    const trimmed = path.trim();
+    if (!trimmed.startsWith('/')) return false;
+    if (trimmed.startsWith('//')) return false;
+    if (trimmed.includes('://')) return false;
+    if (/[\\]/.test(trimmed)) return false;
+    return true;
+};
+
+/**
+ * 검증된 redirect 경로를 반환한다. 유효하지 않으면 fallback('/')을 반환한다.
+ */
+export const getSafeRedirectPath = (path: string | undefined, fallback: string = '/'): string => {
+    if (!path) return fallback;
+    return isValidRedirectPath(path) ? path : fallback;
+};
+
+/**
+ * OAuth 플로우를 위해 redirect 경로를 sessionStorage에 저장한다.
+ */
+export const saveRedirectUrl = (path: string): void => {
+    if (isValidRedirectPath(path)) {
+        sessionStorage.setItem(REDIRECT_STORAGE_KEY, path);
+    }
+};
+
+/**
+ * sessionStorage에서 redirect 경로를 꺼내고 삭제한다.
+ */
+export const popRedirectUrl = (): string | null => {
+    const path = sessionStorage.getItem(REDIRECT_STORAGE_KEY);
+    sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
+    if (path && isValidRedirectPath(path)) {
+        return path;
+    }
+    return null;
+};

--- a/frontend/src/libs/redirect.ts
+++ b/frontend/src/libs/redirect.ts
@@ -19,7 +19,8 @@ export const isValidRedirectPath = (path: string): boolean => {
  */
 export const getSafeRedirectPath = (path: string | undefined, fallback: string = '/'): string => {
     if (!path) return fallback;
-    return isValidRedirectPath(path) ? path : fallback;
+    const trimmed = path.trim();
+    return isValidRedirectPath(trimmed) ? trimmed : fallback;
 };
 
 /**

--- a/frontend/src/pages/oauth/CallbackPage.tsx
+++ b/frontend/src/pages/oauth/CallbackPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { useOAuthLogin } from '~/features/member';
-import { popRedirectUrl } from '~/libs/redirect';
+import { popRedirectUrl, saveRedirectUrl } from '~/libs/redirect';
 
 export const CallbackPage = () => {
     const navigate = useNavigate();
@@ -23,7 +23,13 @@ export const CallbackPage = () => {
 
         loginMutation.mutateAsync({ provider, code, state })
             .then(() => navigate({ to: savedRedirect ?? '/' }))
-            .catch(() => navigate({ to: '/login' }));
+            .catch(() => {
+                if (savedRedirect) saveRedirectUrl(savedRedirect);
+                navigate({
+                    to: '/login',
+                    search: savedRedirect ? { redirect: savedRedirect } : undefined,
+                });
+            });
     }, [code, error, provider, state, navigate, loginMutation]);
 
     return (

--- a/frontend/src/pages/oauth/CallbackPage.tsx
+++ b/frontend/src/pages/oauth/CallbackPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { useOAuthLogin } from '~/features/member';
+import { popRedirectUrl } from '~/libs/redirect';
 
 export const CallbackPage = () => {
     const navigate = useNavigate();
@@ -18,8 +19,10 @@ export const CallbackPage = () => {
             return;
         }
 
+        const savedRedirect = popRedirectUrl();
+
         loginMutation.mutateAsync({ provider, code, state })
-            .then(() => navigate({ to: '/' }))
+            .then(() => navigate({ to: savedRedirect ?? '/' }))
             .catch(() => navigate({ to: '/login' }));
     }, [code, error, provider, state, navigate, loginMutation]);
 

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -82,6 +82,9 @@ const loginRoute = createRoute({
     getParentRoute: () => RootRoute,
     path: '/login',
     component: Login,
+    validateSearch: z.object({
+        redirect: z.string().optional(),
+    }),
 })
 
 const signupRoute = createRoute({


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #513

---

## 📦 뭘 만들었나요? (What)

로그인 가드에 의해 로그인 페이지로 이동한 사용자가 로그인 완료 후 원래 접근하려던 페이지로 자동 리다이렉트되도록 구현.

- `AuthGuard` / `HostGuard`: 미인증 시 현재 경로를 `redirect` search param으로 전달
- `LoginForm`: 로그인 성공 시 `redirect` param이 있으면 해당 경로로 이동
- `CallbackPage` (OAuth): sessionStorage를 통해 redirect 경로 보존 후 복귀
- `libs/redirect.ts`: redirect URL 검증 유틸리티 (외부 URL, protocol-relative URL 차단)

---

## 왜 이렇게 만들었나요? (Why)

**고민했던 점과 이렇게 결정한 이유**

1. **redirect 경로 전달 방식**: URL search param (`?redirect=...`) vs sessionStorage
   - 일반 로그인: search param 사용 (URL에 명시적으로 보이고, 북마크/공유 가능)
   - OAuth 플로우: 외부 사이트를 거치므로 search param 유실 → sessionStorage에 저장 후 callback에서 복원
   
2. **무한 리다이렉트 루프 방지**: TanStack Router의 `useLocation().search`가 파싱된 객체라서 문자열 결합 시 에러 발생. `window.location`으로 현재 경로를 캡처하고, `useRef`로 중복 리다이렉트를 방지.

3. **보안**: `isValidRedirectPath()`로 외부 URL(`https://evil.com`), protocol-relative URL(`//evil.com`), backslash 경로를 차단하여 Open Redirect 취약점 방지.

---

## 어떻게 테스트했나요? (Test)

- 단위 테스트 (Vitest): 전체 51 파일 / 421 테스트 통과
- 브라우저 테스트 (agent-browser): 개발 서버에서 직접 확인

<details>
<summary>테스트 시나리오</summary>

1. 미인증 상태에서 `/booking/my-bookings` 접근 → `/login?redirect=%2Fbooking%2Fmy-bookings%3Fpage%3D1`로 리다이렉트 ✅
2. 미인증 상태에서 `/host/timeslots` 접근 → `/login?redirect=%2Fhost%2Ftimeslots`로 리다이렉트 ✅
3. `/login` 직접 접근 → redirect param 없이 정상 표시 ✅
4. 무한 리다이렉트 루프 발생 안 함 ✅
5. 외부 URL redirect 시도 → 홈(`/`)으로 fallback ✅ (단위 테스트)
6. redirect 유틸리티: 유효/무효 경로 검증, sessionStorage 저장/소비 ✅ (단위 테스트)

</details>

---

## 참고사항 / 회고 메모 (Notes)

- OAuth 로그인의 전체 플로우(redirect → 로그인 → 원래 페이지 복귀)는 백엔드 API가 필요하여 브라우저 E2E 테스트에서는 리다이렉트 param 전달까지만 확인했습니다.
- `loginRoute`에 `validateSearch`로 `redirect` param을 zod 스키마에 추가하여 TanStack Router의 타입 안전성을 유지합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 시 URL의 redirect 쿼리 파라미터를 읽어 안전한 내부 경로로 이동하도록 지원
  * 소셜 로그인 흐름에서도 리다이렉트 대상 저장/복원 기능 추가
  * 로그인 라우트에 redirect 쿼리 검증 추가

* **버그 수정**
  * 인증 가드에서 중복 리다이렉트를 방지하도록 수정

* **테스트**
  * 리다이렉트 유효성 및 저장/복원 동작을 검증하는 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->